### PR TITLE
Patch to respect LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ $(EXEC): $(OBJS) $(HDRS)
 	$(CC) $(LDFLAGS) -o $@ $(OBJS) $(LDLIBS)
 
 $(CONTROL_EXEC): $(CONTROL_SRCS)
-	$(CC) $(CONTROL_SRCS) -o $@
+	$(CC) $(LDFLAGS) $(CONTROL_SRCS) -o $@
 
 pfc:
 	$(CC) $(CFLAGS) -c contrib/pfc.c


### PR DESCRIPTION
Originally patched in Gentoo Linux, orignal author unknown for contribution.
