### PR TITLE
Respect CFLAGS for xl2tpd-control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ $(EXEC): $(OBJS) $(HDRS)
 	$(CC) $(LDFLAGS) -o $@ $(OBJS) $(LDLIBS)
 
 $(CONTROL_EXEC): $(CONTROL_SRCS)
-	$(CC) $(LDFLAGS) $(CONTROL_SRCS) -o $@
+	$(CC) $(CFLAGS) $(LDFLAGS) $(CONTROL_SRCS) -o $@
 
 pfc:
 	$(CC) $(CFLAGS) -c contrib/pfc.c


### PR DESCRIPTION
Similar to issue #4. Since we are compiling and linking in one step, we should also pass CFLAGS.
