### PR TITLE
remove a 'sleep' in control_finish which may cause xl2tpd blocked under heavy traffic.

### DIFF
--- a/control.c
+++ b/control.c
@@ -495,7 +495,7 @@ int control_finish (struct tunnel *t, struct call *c)
         c->cnu = 0;
         if (gconfig.debug_state)
             l2tp_log (LOG_DEBUG, "%s: sending SCCRP\n", __FUNCTION__);
-		sleep(2);
+
         control_xmit (buf);
         break;
     case SCCRP:


### PR DESCRIPTION
I have tested that removing 'sleep' in control_finish can resolve the bug which made xl2tpd blocked under heavy traffic.
