### PR TITLE
Fix udp_xmit to work on Linux *and* OpenBSD

### DIFF
--- a/network.c
+++ b/network.c
@@ -277,10 +277,9 @@ void udp_xmit (struct buffer *buf, struct tunnel *t)
      */
     memset(&msgh, 0, sizeof(struct msghdr));
 
-    msgh.msg_control = cbuf;
-    msgh.msg_controllen = sizeof(cbuf);
-
     if(gconfig.ipsecsaref && t->refhim != IPSEC_SAREF_NULL) {
+        msgh.msg_control = cbuf;
+
 	cmsg = CMSG_FIRSTHDR(&msgh);
 	cmsg->cmsg_level = IPPROTO_IP;
 	cmsg->cmsg_type  = gconfig.sarefnum;


### PR DESCRIPTION
OpenBSD's sendmsg doesn't like it if a struct msghdr's msg_control is
set to something but msg_controllen is zero.  Linux, on the other hand,
doesn't like it if msg_controllen is non-zero but the control message
itself is not populated.  Let's avoid the whole issue by leaving both
fields as zero unless we actually have some ancillary data to send.

This reworks the changes in 83419fc90de766bf7b614b60603bd2af316a9a62 in a way that should work, but I don't have access to an OpenBSD box to test.  sthen, could please you see if this works for you?
