### PR TITLE
Set msgh.msg_controllen before calling CMSG_FIRSTHDR

### DIFF
--- a/network.c
+++ b/network.c
@@ -279,6 +279,7 @@ void udp_xmit (struct buffer *buf, struct tunnel *t)
 
     if(gconfig.ipsecsaref && t->refhim != IPSEC_SAREF_NULL) {
         msgh.msg_control = cbuf;
+        msgh.msg_controllen = sizeof(cbuf);
 
 	cmsg = CMSG_FIRSTHDR(&msgh);
 	cmsg->cmsg_level = IPPROTO_IP;


### PR DESCRIPTION
It turns out that CMSG_FIRSTHDR refers to msg_controllen.  Be sure to
set it to something sane before invoking that macro.

This is probably needed for OpenBSD.
