### PR TITLE
Tell pppd to set LNS mode flag on kernel pppol2tp session socket.

### DIFF
--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -421,6 +421,17 @@ int start_pppd (struct call *c, struct ppp_opts *opts)
        stropt[pos] = (char *) malloc (10);
        snprintf (stropt[pos], 10, "%d", fd2);
         pos++;
+       if (c->container->lns) {
+        stropt[pos++] = strdup ("pppol2tp_lns_mode");
+        stropt[pos++] = strdup ("pppol2tp_tunnel_id");
+        stropt[pos] = (char *) malloc (10);
+        snprintf (stropt[pos], 10, "%d", c->container->ourtid);
+            pos++;
+        stropt[pos++] = strdup ("pppol2tp_session_id");
+        stropt[pos] = (char *) malloc (10);
+        snprintf (stropt[pos], 10, "%d", c->ourcid);
+            pos++;
+       }
         stropt[pos] = NULL;
     }
     else


### PR DESCRIPTION
This flag is needed to set LNS mode on kernel socket for correct
functioning of pppd and xl2tpd in LNS mode.
