### PR TITLE
Use address from the last received UDP packet in UDP messages response

### DIFF
--- a/l2tp.h
+++ b/l2tp.h
@@ -172,6 +172,7 @@ struct tunnel
     struct call *self;
     struct lns *lns;            /* LNS that owns us */
     struct lac *lac;            /* LAC that owns us */
+    struct in_pktinfo my_addr;  /* Address of my endpoint */
 };
 
 struct tunnel_list


### PR DESCRIPTION
This patch fixes situations, where there is more interfaces / or / IP addresses on interface.
It forces to use the same source IP in responses, that was used as a destination in original request.

Originally, I created the patch on 1.3.1 branch (not public), but since it could be usefull for others, I applied it on the master and decided to share.
