### PR TITLE
fix build with musl

### DIFF
--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -30,7 +30,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <time.h>
-#if (__GLIBC__ < 2)
+#if defined (__GLIBC__) && (__GLIBC__ < 2)
 # if defined(FREEBSD) || defined(OPENBSD)
 #  include <sys/signal.h>
 # elif defined(LINUX)


### PR DESCRIPTION
musl doesn't define __GLIBC__ and provides <socket.h> rather
than <bsd/socket.h>, making the build fail.
Fix that by checking if __GLIBC__ is defined at all before
checking its version.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>