### PR TITLE
Fix to endless looping when EHOSTUNREACH received

### DIFF
--- a/network.c
+++ b/network.c
@@ -545,6 +545,7 @@ void network_thread ()
                     l2tp_log (LOG_WARNING, "%s: received too small a packet\n",
                          __FUNCTION__);
                 }
+		if (st) st=st->next;
 		continue;
             }
 


### PR DESCRIPTION
I have found that xl2tpd will occasionally go into an endless loop. It seems to be when the recvmsg in network.c gets a error 113 (EHOSTUNREACH). I get this message in the syslog:-

xl2tpd[3735]: network_thread: recvfrom returned error 113 (No route to host)

At which point xl2tpd goes into an endless loop, calling recvmsg and getting EAGAIN - according to strace on the process.

From what I understand EHOSTUNREACH is normally a fairly transient error (probably network related) and may not even be related to the current fd that is being read. The problem is that xl2tpd loops back round and tries to do another (non blocking) readmsg from the same fd. However because there is nothing there gets an EAGAIN and so tries again.

I think the fix (but I am not an expert in the code) is to move onto the next fd on any error including EAGAIN, just as it does when it successfully reads from the fd. I note that the code does handle ECONNREFUSED and EBADF properly (closes the fd and marks it). However no other error codes. I originally just changed it to handle EHOSTUNREACH in the same way, however that really doesn't deal with any other error code that could crop up.