### PR TITLE
solve some memory leaks that show up after several days of running

### DIFF
--- a/avp.c
+++ b/avp.c
@@ -502,7 +502,7 @@ int result_code_avp (struct tunnel *t, struct call *c, void *data,
         return 0;
     }
 
-    if ((c->msgtype == CDN) && ((result > 11) || (result < 1)))
+    if ((c->msgtype == CDN) && ((result > 10) || (result < 1)))
     {
         if (DEBUG)
             l2tp_log (LOG_DEBUG,

--- a/avp.c
+++ b/avp.c
@@ -104,6 +104,7 @@ char *cdn_result_codes[] = {
     "Call failed due to lack of appropriate facilities being available (permanent condition)",
     "Invalid destination",
     "Call failed due to no carrier detected",
+    "Call failed due to detection of a busy signal",
     "Call failed due to lack of a dial tone",
     "Call was no established within time allotted by LAC",
     "Call was connected but no appropriate framing was detect"
@@ -502,7 +503,7 @@ int result_code_avp (struct tunnel *t, struct call *c, void *data,
         return 0;
     }
 
-    if ((c->msgtype == CDN) && ((result > 10) || (result < 1)))
+    if ((c->msgtype == CDN) && ((result > 11) || (result < 1)))
     {
         if (DEBUG)
             l2tp_log (LOG_DEBUG,

--- a/call.c
+++ b/call.c
@@ -476,6 +476,8 @@ void destroy_call (struct call *c)
             c->lac->rsched = schedule (tv, magic_lac_dial, c->lac);
         }
     }
+    if(c->oldptyconf)
+		free(c->oldptyconf);
 
     free (c);
 }
@@ -484,7 +486,7 @@ void destroy_call (struct call *c)
 struct call *new_call (struct tunnel *parent)
 {
     unsigned char entropy_buf[2] = "\0";
-    struct call *tmp = malloc (sizeof (struct call));
+    struct call *tmp = calloc (1,sizeof (struct call));
 
     if (!tmp)
         return NULL;

--- a/call.c
+++ b/call.c
@@ -317,7 +317,7 @@ void call_close (struct call *c)
             tmp = tmp2;
         }
         l2tp_log (LOG_INFO,
-             "Connection %d closed to %s, port %d (%s)\n", 
+             "Connection %d closed to %s, port %d (%s)\n",
              c->container->tid,
              IPADDY (c->container->peer.sin_addr),
              ntohs (c->container->peer.sin_port), c->errormsg);
@@ -389,7 +389,10 @@ void destroy_call (struct call *c)
      * Close the tty
      */
     if (c->fd > 0)
+    {
         close (c->fd);
+        c->fd = -1;
+    }
 /*	if (c->dethrottle) deschedule(c->dethrottle); */
     if (c->zlb_xmit)
         deschedule (c->zlb_xmit);
@@ -401,7 +404,7 @@ void destroy_call (struct call *c)
 #endif
 
     /*
-     * Kill off pppd and wait for it to 
+     * Kill off pppd and wait for it to
      * return to us.  This should only be called
      * in rare cases if pppd hasn't already died
      * voluntarily
@@ -562,8 +565,8 @@ struct call *new_call (struct tunnel *parent)
 /*	if (tmp->ourrws >= 0)
 		tmp->ourfbit = FBIT;
 	else */
-    tmp->ourfbit = 0;           /* initialize to 0 since we don't actually use this 
-                                   value at this point anywhere in the code (I don't 
+    tmp->ourfbit = 0;           /* initialize to 0 since we don't actually use this
+                                   value at this point anywhere in the code (I don't
                                    think)  We might just be able to remove it completely */
     tmp->dial_no[0] = '\0';     /* jz: dialing number for outgoing call */
     return tmp;
@@ -591,7 +594,7 @@ struct call *get_call (int tunnel, int call,  struct in_addr addr, int port,
 		       IPsecSAref_t refme, IPsecSAref_t refhim)
 {
     /*
-     * Figure out which call struct should handle this. 
+     * Figure out which call struct should handle this.
      * If we have tunnel and call ID's then they are unique.
      * Otherwise, if the tunnel is 0, look for an existing connection
      * or create a new tunnel.

--- a/control.c
+++ b/control.c
@@ -77,7 +77,7 @@ struct buffer *new_outgoing (struct tunnel *t)
 
 inline void recycle_outgoing (struct buffer *buf, struct sockaddr_in peer)
 {
-    /* 
+    /*
      * This should only be used for ZLB's!
      */
     buf->start = buf->rstart + sizeof (struct control_hdr);
@@ -179,7 +179,7 @@ int control_finish (struct tunnel *t, struct call *c)
     char dummy_buf[128] = "/var/l2tp/"; /* jz: needed to read /etc/ppp/var.options - just kick it if you don't like */
     char passwdfd_buf[32] = ""; /* buffer for the fd, not the password */
     int i;
-    int pppd_passwdfd[2];            
+    int pppd_passwdfd[2];
     int tmptid,tmpcid;
 
     if (c->msgtype < 0)
@@ -392,7 +392,7 @@ int control_finish (struct tunnel *t, struct call *c)
         /* FIXME: Do we need to be sure they specified a version number?
          *   Theoretically, yes, but we don't have anything in the code
          *   to actually *do* anything with it, so...why check at this point?
-         * We shouldn't be requiring a bearer capabilities avp to be present in 
+         * We shouldn't be requiring a bearer capabilities avp to be present in
          * SCCRQ and SCCRP as they aren't required
          if (t->bc < 0 ) {
          if (DEBUG) l2tp_log(LOG_DEBUG,
@@ -516,7 +516,7 @@ int control_finish (struct tunnel *t, struct call *c)
         /* FIXME: Do we need to be sure they specified a version number?
          *   Theoretically, yes, but we don't have anything in the code
          *   to actually *do* anything with it, so...why check at this point?
-         * We shouldn't be requiring a bearer capabilities avp to be present in 
+         * We shouldn't be requiring a bearer capabilities avp to be present in
          * SCCRQ and SCCRP as they aren't required
          if (t->bc < 0 ) {
          if (DEBUG) log(LOG_DEBUG,
@@ -713,7 +713,7 @@ int control_finish (struct tunnel *t, struct call *c)
                 l2tp_log (LOG_DEBUG,
                      "%s: Peer tried to initiate call without call ID\n",
                      __FUNCTION__);
-            /* Here it doesn't make sense to use the needclose flag because 
+            /* Here it doesn't make sense to use the needclose flag because
                the call p did not receive any packets */
             call_close (p);
             return -EINVAL;
@@ -877,7 +877,7 @@ int control_finish (struct tunnel *t, struct call *c)
             if (c->lac->debug)
                 po = add_opt (po, "debug");
             if (c->lac->password[0])
-            {                    
+            {
                 if (pipe (pppd_passwdfd) == -1)
                 {
                   l2tp_log (LOG_DEBUG,
@@ -1063,8 +1063,8 @@ int control_finish (struct tunnel *t, struct call *c)
         /*  jz: just show some information */
         l2tp_log (LOG_INFO,
 		  "parameters: Local: %d , Remote: %d , Serial: %d , Pid: %d , Tunnelid: %d , Phoneid: %s\n",
-		  c->ourcid, c->cid, c->serno, c->pppd, t->ourtid, c->dial_no); 
-	
+		  c->ourcid, c->cid, c->serno, c->pppd, t->ourtid, c->dial_no);
+
         opt_destroy (po);
         if (c->lac)
             c->lac->rtries = 0;
@@ -1182,7 +1182,7 @@ inline int check_control (const struct buffer *buf, struct tunnel *t,
             l2tp_log (LOG_DEBUG,
                  "%s: Received out of order control packet on tunnel %d (got %d, expected %d)\n",
                  __FUNCTION__, t->tid, h->Ns, t->control_rec_seq_num);
-        if (((h->Ns < t->control_rec_seq_num) && 
+        if (((h->Ns < t->control_rec_seq_num) &&
             ((t->control_rec_seq_num - h->Ns) < 32768)) ||
             ((h->Ns > t->control_rec_seq_num) &&
             ((t->control_rec_seq_num - h->Ns) > 32768)))
@@ -1297,7 +1297,7 @@ inline int check_payload (struct buffer *buf, struct tunnel *t,
     }
     if (buf->len < MIN_PAYLOAD_HDR_LEN)
     {
-        /* has to be at least MIN_PAYLOAD_HDR_LEN 
+        /* has to be at least MIN_PAYLOAD_HDR_LEN
            no matter what.  we'll look more later */
         if (DEBUG)
         {
@@ -1478,9 +1478,9 @@ inline int expand_payload (struct buffer *buf, struct tunnel *t,
     if (new_hdr->Ns != c->data_seq_num)
     {
         /* RFC1982-esque comparison of serial numbers */
-        if (((new_hdr->Ns < c->data_rec_seq_num) && 
+        if (((new_hdr->Ns < c->data_rec_seq_num) &&
             ((c->data_rec_seq_num - new_hdr->Ns) < 32768)) ||
-            ((new_hdr->Ns > c->data_rec_seq_num) && 
+            ((new_hdr->Ns > c->data_rec_seq_num) &&
             ((c->data_rec_seq_num - new_hdr->Ns) > 32768)))
         {
 #ifdef DEBUG_FLOW
@@ -1582,7 +1582,7 @@ inline int write_packet (struct buffer *buf, struct tunnel *t, struct call *c,
         return -EIO;
     }
     /*
-     * Skip over header 
+     * Skip over header
      */
     _u16 offset = ((struct payload_hdr*)(buf->start))->o_size;  // For FIXME:
     buf->start += sizeof(struct payload_hdr) + offset;
@@ -1698,7 +1698,7 @@ inline int write_packet (struct buffer *buf, struct tunnel *t, struct call *c,
     return 0;
 }
 
-void handle_special (struct buffer *buf, struct call *c, _u16 call)
+int handle_special (struct buffer *buf, struct call *c, _u16 call)
 {
     /*
        * This procedure is called when we have received a packet
@@ -1710,7 +1710,7 @@ void handle_special (struct buffer *buf, struct call *c, _u16 call)
     struct tunnel *t = c->container;
     /* Don't do anything unless it's a control packet */
     if (!CTBIT (*((_u16 *) buf->start)))
-        return;
+        return 0;
     /* Temporarily, we make the tunnel have cid of call instead of 0,
        but we need to stop any scheduled events (like Hello's in
        particular) which might use this value */
@@ -1723,7 +1723,7 @@ void handle_special (struct buffer *buf, struct call *c, _u16 call)
             if (gconfig.debug_tunnel)
                 l2tp_log (LOG_DEBUG, "%s: ZLB for closed call\n", __FUNCTION__);
             c->cid = 0;
-            return;
+            return 0;
         }
         /* Make a packet with the specified call number */
         /* FIXME: If I'm not a CDN, I need to send a CDN */
@@ -1731,6 +1731,7 @@ void handle_special (struct buffer *buf, struct call *c, _u16 call)
         c->cid = 0;
         udp_xmit (buf, t);
         toss (buf);
+        return 1;
     }
     else
     {
@@ -1738,6 +1739,7 @@ void handle_special (struct buffer *buf, struct call *c, _u16 call)
         if (gconfig.debug_tunnel)
             l2tp_log (LOG_DEBUG, "%s: invalid control packet\n", __FUNCTION__);
     }
+    return 0;
 }
 
 inline int handle_packet (struct buffer *buf, struct tunnel *t,
@@ -1819,10 +1821,10 @@ inline int handle_packet (struct buffer *buf, struct tunnel *t,
                     res = write_packet (buf, t, c, SYNC_FRAMING);
                     if (res)
                         return res;
-                    /* 
+                    /*
                        * Assuming we wrote to the ppp driver okay, we should
                        * do something about ZLB's unless *we* requested no
-                       * window size or if they we have turned off our fbit. 
+                       * window size or if they we have turned off our fbit.
                      */
 
 /*					if (c->ourfbit && (c->ourrws > 0)) {

--- a/control.h
+++ b/control.h
@@ -59,7 +59,7 @@ extern void add_control_hdr (struct tunnel *t, struct call *c,
 extern int control_finish (struct tunnel *t, struct call *c);
 extern void control_zlb (struct buffer *, struct tunnel *, struct call *);
 extern void recycle_outgoing (struct buffer *, struct sockaddr_in);
-extern void handle_special (struct buffer *, struct call *, _u16);
+extern int handle_special (struct buffer *, struct call *, _u16);
 extern void hello (void *);
 extern void send_zlb (void *);
 extern void dethrottle (void *);

--- a/l2tp.h
+++ b/l2tp.h
@@ -170,11 +170,6 @@ struct tunnel
     _u16 control_seq_num;       /* Sequence for next packet */
     _u16 control_rec_seq_num;   /* Next expected to receive */
     int cLr;                    /* Last packet received by peer */
-    char hostname[MAXSTRLEN];   /* Remote hostname */
-    char vendor[MAXSTRLEN];     /* Vendor of remote product */
-    struct challenge chal_us;   /* Their Challenge to us */
-    struct challenge chal_them; /* Our challenge to them */
-    char secret[MAXSTRLEN];     /* Secret to use */
 #ifdef SANITY
     int sanity;                 /* check for sanity? */
 #endif
@@ -188,6 +183,11 @@ struct tunnel
     struct lns *lns;            /* LNS that owns us */
     struct lac *lac;            /* LAC that owns us */
     struct in_pktinfo my_addr;  /* Address of my endpoint */
+    char hostname[MAXSTRLEN];   /* Remote hostname */
+    char vendor[MAXSTRLEN];     /* Vendor of remote product */
+    struct challenge chal_us;   /* Their Challenge to us */
+    struct challenge chal_them; /* Our challenge to them */
+    char secret[MAXSTRLEN];     /* Secret to use */
 };
 
 struct tunnel_list

--- a/md5.h
+++ b/md5.h
@@ -4,7 +4,8 @@
 #ifdef __alpha
 typedef unsigned int uint32;
 #else
-typedef unsigned long uint32;
+#include <stdint.h>
+typedef uint32_t uint32;
 #endif
 
 struct MD5Context

--- a/misc.c
+++ b/misc.c
@@ -80,10 +80,15 @@ void set_error (struct call *c, int error, const char *fmt, ...)
 
 struct buffer *new_buf (int size)
 {
-    struct buffer *b = malloc (sizeof (struct buffer));
+    struct buffer *b = NULL;
 
-    if (!b || !size || size < 0)
+    if (!size || size < 0)
         return NULL;
+
+    b = malloc (sizeof (struct buffer));
+    if (!b)
+        return NULL;
+
     b->rstart = malloc (size);
     if (!b->rstart)
     {
@@ -225,7 +230,7 @@ struct ppp_opts *add_opt (struct ppp_opts *option, char *fmt, ...)
         l2tp_log (LOG_WARNING,
 		  "%s : Unable to allocate ppp option memory.  Expect a crash\n",
 		  __FUNCTION__);
-        return NULL;
+        return option;
     }
     new->next = NULL;
     va_start (args, fmt);

--- a/network.c
+++ b/network.c
@@ -708,6 +708,8 @@ int connect_pppol2tp(struct tunnel *t) {
             struct sockaddr_pppol2tp sax;
 
             struct sockaddr_in server;
+
+            memset(&server, 0, sizeof(struct sockaddr_in));
             server.sin_family = AF_INET;
             server.sin_addr.s_addr = gconfig.listenaddr;
             server.sin_port = htons (gconfig.port);
@@ -741,6 +743,7 @@ int connect_pppol2tp(struct tunnel *t) {
             if (connect (ufd, (struct sockaddr *) &server, sizeof(server)) < 0) {
                 l2tp_log (LOG_CRIT, "%s: Unable to connect UDP peer. Terminating.\n",
                  __FUNCTION__);
+                close(ufd);
                 return -EINVAL;
             }
 
@@ -756,6 +759,7 @@ int connect_pppol2tp(struct tunnel *t) {
             if (flags == -1 || fcntl(fd2, F_SETFL, flags | O_NONBLOCK) == -1) {
                 l2tp_log (LOG_WARNING, "%s: Unable to set PPPoL2TP socket nonblock.\n",
                      __FUNCTION__);
+                close(fd2);
                 return -EINVAL;
             }
             memset(&sax, 0, sizeof(sax));

--- a/network.c
+++ b/network.c
@@ -483,7 +483,8 @@ void network_thread ()
         server_socket_processed = 0;
         currentfd = NULL;
         st = tunnels.head;
-        while (st || !server_socket_processed) {
+        while (st || !server_socket_processed)
+		{
             if (st && (st->udp_fd == -1)) {
                 st=st->next;
                 continue;
@@ -594,13 +595,10 @@ void network_thread ()
 	    {
 		do_packet_dump (buf);
 	    }
-	    if (!
-		(c = get_call (tunnel, call, from.sin_addr,
+			if (!(c = get_call (tunnel, call, from.sin_addr,
 			       from.sin_port, refme, refhim)))
 	    {
-		if ((c =
-		     get_tunnel (tunnel, from.sin_addr.s_addr,
-				 from.sin_port)))
+				if ((c = get_tunnel (tunnel, from.sin_addr.s_addr, from.sin_port)))
 		{
 		    /*
 		     * It is theoretically possible that we could be sent
@@ -617,7 +615,8 @@ void network_thread ()
 		    handle_special (buf, c, call);
 
 		    /* get a new buffer */
-		    buf = new_buf (MAX_RECV_SIZE);
+		// 		    buf = new_buf (MAX_RECV_SIZE);
+					recycle_buf (buf);
 		}
 		else
 		    l2tp_log (LOG_DEBUG,
@@ -645,7 +644,7 @@ void network_thread ()
 		    control_zlb (buf, c->container, c);
 		    c->cnu = 0;
 		}
-	    };
+			}
 	}
 	if (st) st=st->next;
 	}

--- a/network.c
+++ b/network.c
@@ -43,7 +43,7 @@ int init_network (void)
     unsigned int length = sizeof (server);
     gethostname (hostname, sizeof (hostname));
     server.sin_family = AF_INET;
-    server.sin_addr.s_addr = gconfig.listenaddr; 
+    server.sin_addr.s_addr = gconfig.listenaddr;
     server.sin_port = htons (gconfig.port);
     int flags;
     if ((server_socket = socket (PF_INET, SOCK_DGRAM, 0)) < 0)
@@ -85,7 +85,7 @@ int init_network (void)
 
 	    gconfig.ipsecsaref=0;
     }
-    
+
     arg=1;
     if(setsockopt(server_socket, IPPROTO_IP, IP_PKTINFO, (char*)&arg, sizeof(arg)) != 0) {
 	    l2tp_log(LOG_CRIT, "setsockopt IP_PKTINFO: %s\n", strerror(errno));
@@ -138,7 +138,7 @@ int init_network (void)
 inline void extract (void *buf, int *tunnel, int *call)
 {
     /*
-     * Extract the tunnel and call #'s, and fix the order of the 
+     * Extract the tunnel and call #'s, and fix the order of the
      * version
      */
 
@@ -189,11 +189,11 @@ void dethrottle (void *call)
 /*	struct call *c = (struct call *)call; */
 /*	if (c->throttle) {
 #ifdef DEBUG_FLOW
-		log(LOG_DEBUG, "%s: dethrottling call %d, and setting R-bit\n",__FUNCTION__,c->ourcid); 
+		log(LOG_DEBUG, "%s: dethrottling call %d, and setting R-bit\n",__FUNCTION__,c->ourcid);
 #endif 		c->rbit = RBIT;
 		c->throttle = 0;
 	} else {
-		log(LOG_DEBUG, "%s:  call %d already dethrottled?\n",__FUNCTION__,c->ourcid); 	
+		log(LOG_DEBUG, "%s:  call %d already dethrottled?\n",__FUNCTION__,c->ourcid);
 	} */
 }
 
@@ -287,7 +287,7 @@ void udp_xmit (struct buffer *buf, struct tunnel *t)
     struct iovec iov;
     struct in_pktinfo *pktinfo;
     int finallen;
-    
+
     /*
      * OKAY, now send a packet with the right SAref values.
      */
@@ -309,38 +309,38 @@ void udp_xmit (struct buffer *buf, struct tunnel *t)
 	}
 	refp = (unsigned int *)CMSG_DATA(cmsg);
 	*refp = t->refhim;
-	
+
 	finallen = cmsg->cmsg_len;
     }
-    
+
     if (t->my_addr.ipi_addr.s_addr){
 
 	if ( ! cmsg) {
-		cmsg = CMSG_FIRSTHDR(&msgh);		
+		cmsg = CMSG_FIRSTHDR(&msgh);
 	}
 	else {
 		cmsg = CMSG_NXTHDR(&msgh, cmsg);
 	}
-	
+
 	cmsg->cmsg_level = IPPROTO_IP;
 	cmsg->cmsg_type = IP_PKTINFO;
 	cmsg->cmsg_len = CMSG_LEN(sizeof(struct in_pktinfo));
 
 	pktinfo = (struct in_pktinfo*) CMSG_DATA(cmsg);
 	*pktinfo = t->my_addr;
-	
+
 	finallen += cmsg->cmsg_len;
     }
-    
+
     msgh.msg_controllen = finallen;
-    
+
     iov.iov_base = buf->start;
     iov.iov_len  = buf->len;
 
     /* return packet from whence it came */
     msgh.msg_name    = &buf->peer;
     msgh.msg_namelen = sizeof(buf->peer);
-    
+
     msgh.msg_iov  = &iov;
     msgh.msg_iovlen = 1;
     msgh.msg_flags = 0;
@@ -508,9 +508,9 @@ void network_thread ()
 
 	    memset(&from, 0, sizeof(from));
 	    memset(&to,   0, sizeof(to));
-	    
+
 	    fromlen = sizeof(from);
-	    
+
 	    memset(&msgh, 0, sizeof(struct msghdr));
 	    iov.iov_base = buf->start;
 	    iov.iov_len  = buf->len;
@@ -521,7 +521,7 @@ void network_thread ()
 	    msgh.msg_iov  = &iov;
 	    msgh.msg_iovlen = 1;
 	    msgh.msg_flags = 0;
-	    
+
 	    /* Receive one packet. */
 	    recvsize = recvmsg(*currentfd, &msgh, 0);
 
@@ -567,7 +567,7 @@ void network_thread ()
 			else if (gconfig.ipsecsaref && cmsg->cmsg_level == IPPROTO_IP
 			&& cmsg->cmsg_type == gconfig.sarefnum) {
 				unsigned int *refp;
-				
+
 				refp = (unsigned int *)CMSG_DATA(cmsg);
 				refme =refp[0];
 				refhim=refp[1];
@@ -595,57 +595,54 @@ void network_thread ()
 	    {
 		do_packet_dump (buf);
 	    }
-			if (!(c = get_call (tunnel, call, from.sin_addr,
-			       from.sin_port, refme, refhim)))
-	    {
-				if ((c = get_tunnel (tunnel, from.sin_addr.s_addr, from.sin_port)))
-		{
-		    /*
-		     * It is theoretically possible that we could be sent
-		     * a control message (say a StopCCN) on a call that we
-		     * have already closed or some such nonsense.  To
-		     * prevent this from closing the tunnel, if we get a
-		     * call on a valid tunnel, but not with a valid CID,
-		     * we'll just send a ZLB to ack receiving the packet.
-		     */
-		    if (gconfig.debug_tunnel)
-			l2tp_log (LOG_DEBUG,
-				  "%s: no such call %d on tunnel %d.  Sending special ZLB\n",
-				  __FUNCTION__);
-		    handle_special (buf, c, call);
+        if (!(c = get_call (tunnel, call, from.sin_addr,
+                from.sin_port, refme, refhim)))
+        {
+            if ((c = get_tunnel (tunnel, from.sin_addr.s_addr, from.sin_port)))
+            {
+                /*
+                * It is theoretically possible that we could be sent
+                * a control message (say a StopCCN) on a call that we
+                * have already closed or some such nonsense.  To
+                * prevent this from closing the tunnel, if we get a
+                * call on a valid tunnel, but not with a valid CID,
+                * we'll just send a ZLB to ack receiving the packet.
+                */
+                if (gconfig.debug_tunnel)
+                l2tp_log (LOG_DEBUG,
+                    "%s: no such call %d on tunnel %d.  Sending special ZLB\n",
+                    __FUNCTION__);
+                if(1==handle_special (buf, c, call)) {
+                    buf = new_buf (MAX_RECV_SIZE);
+                }
+            }
+            else
+                l2tp_log (LOG_DEBUG,
+                    "%s: unable to find call or tunnel to handle packet.  call = %d, tunnel = %d Dumping.\n",
+                    __FUNCTION__, call, tunnel);
+        }
+        else
+        {
+            if (c->container) {
+                c->container->my_addr = to;
+            }
 
-		    /* get a new buffer */
-		// 		    buf = new_buf (MAX_RECV_SIZE);
-					recycle_buf (buf);
-		}
-		else
-		    l2tp_log (LOG_DEBUG,
-			      "%s: unable to find call or tunnel to handle packet.  call = %d, tunnel = %d Dumping.\n",
-			      __FUNCTION__, call, tunnel);
-		
-	    }
-	    else
-	    {
-		if (c->container) {
-			c->container->my_addr = to;
-		}
-
-		buf->peer = from;
-		/* Handle the packet */
-		c->container->chal_us.vector = NULL;
-		if (handle_packet (buf, c->container, c))
-		{
-		    if (gconfig.debug_tunnel)
-			l2tp_log (LOG_DEBUG, "%s: bad packet\n", __FUNCTION__);
-		};
-		if (c->cnu)
-		{
-		    /* Send Zero Byte Packet */
-		    control_zlb (buf, c->container, c);
-		    c->cnu = 0;
-		}
-			}
-	}
+            buf->peer = from;
+            /* Handle the packet */
+            c->container->chal_us.vector = NULL;
+            if (handle_packet (buf, c->container, c))
+            {
+                if (gconfig.debug_tunnel)
+                l2tp_log (LOG_DEBUG, "%s: bad packet\n", __FUNCTION__);
+            }
+            if (c->cnu)
+            {
+                /* Send Zero Byte Packet */
+                control_zlb (buf, c->container, c);
+                c->cnu = 0;
+            }
+        }
+    }
 	if (st) st=st->next;
 	}
 

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -339,6 +339,7 @@ void death_handler (int signal)
     /* erase pid and control files */
     unlink (gconfig.pidfile);
     unlink (gconfig.controlfile);
+	free(dial_no_tmp);
 
     exit (1);
 }
@@ -588,7 +589,7 @@ void destroy_tunnel (struct tunnel *t)
      * "suicide safe"
      */
 
-    struct call *c, *me;
+    struct call *c, *me, *next;
     struct tunnel *p;
     struct timeval tv;
     if (!t)
@@ -609,8 +610,9 @@ void destroy_tunnel (struct tunnel *t)
     c = t->call_head;
     while (c)
     {
+		next = c->next;
         destroy_call (c);
-        c = c->next;
+        c = next;
     };
     /*
      * Remove ourselves from the list of tunnels
@@ -676,6 +678,8 @@ void destroy_tunnel (struct tunnel *t)
     if (t->udp_fd > -1 )
         close (t->udp_fd);
     free (t);
+	if(me->oldptyconf)
+		free(me->oldptyconf);
     free (me);
 }
 

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -518,6 +518,7 @@ int start_pppd (struct call *c, struct ppp_opts *opts)
     {
         /* parent */
         l2tp_log(LOG_WARNING,"%s: unable to fork(), abandoning!\n", __FUNCTION__);
+        close(fd2);
         return -EINVAL;
     }
     else if (!c->pppd)
@@ -1689,13 +1690,14 @@ void daemonize() {
 
     close(0);
     i = open("/dev/null", O_RDWR);
-    if (i != 0) {
+    if (i == -1) {
         l2tp_log(LOG_INFO, "Redirect of stdin to /dev/null failed\n");
     } else {
         if (dup2(0, 1) == -1)
             l2tp_log(LOG_INFO, "Redirect of stdout to /dev/null failed\n");
         if (dup2(0, 2) == -1)
             l2tp_log(LOG_INFO, "Redirect of stderr to /dev/null failed\n");
+        close(i);
     }
 #endif
 }

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -1067,6 +1067,16 @@ int control_handle_available(FILE* resf, char* bufp){
 
     write_res (resf, "%02i AVAILABLE lac.count=%d\n", 0, lac_count);
 
+	struct tunnel *st;
+	st = tunnels.head;
+	while (st)
+	{
+		write_res (resf, "%02i AVAILABLE tunnel %p, id %d has %d calls and self %p\n", 0, st, st->tid, st->count, st->self);
+		st = st->next;
+	}
+
+	write_res (resf, "%02i AVAILABLE tunnels count=%d\n", 0, tunnels.count);
+	write_res (resf, "%02i AVAILABLE calls count=%d\n", 0, tunnels.calls);
 	return 1;
 }
 

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -549,18 +549,17 @@ int start_pppd (struct call *c, struct ppp_opts *opts)
              if (kernel_support) {
                  close(st->udp_fd); /* tunnel UDP fd */
                  close(st->pppox_fd); /* tunnel PPPoX fd */
-             } else {
+             } else
 #endif
+			 {
                  sc = st->call_head;
                  while (sc)
                  {
                      close (sc->fd); /* call pty fd */
                      sc = sc->next;
                  }
-                 st = st->next;
-#ifdef USE_KERNEL
-             }
-#endif
+			 }
+             st = st->next;
         }
 
         /* close the UDP socket fd */
@@ -1067,7 +1066,8 @@ int control_handle_available(FILE* resf, char* bufp){
     }
 
     write_res (resf, "%02i AVAILABLE lac.count=%d\n", 0, lac_count);
-    return 1;
+
+	return 1;
 }
 
 int control_handle_lns_add_modify(FILE* resf, char* bufp){

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -547,15 +547,18 @@ int start_pppd (struct call *c, struct ppp_opts *opts)
         {
 #ifdef USE_KERNEL
              if (kernel_support) {
-                 close(st->udp_fd); /* tunnel UDP fd */
-                 close(st->pppox_fd); /* tunnel PPPoX fd */
+                if(st->udp_fd!=-1)
+                    close(st->udp_fd); /* tunnel UDP fd */
+                if(st->pppox_fd!=-1)
+                    close(st->pppox_fd); /* tunnel PPPoX fd */
              } else
 #endif
 			 {
                  sc = st->call_head;
                  while (sc)
                  {
-                     close (sc->fd); /* call pty fd */
+                     if(sc->fd!=-1)
+                        close (sc->fd); /* call pty fd */
                      sc = sc->next;
                  }
 			 }
@@ -563,10 +566,12 @@ int start_pppd (struct call *c, struct ppp_opts *opts)
         }
 
         /* close the UDP socket fd */
-        close (server_socket);
+        if(server_socket!=-1)
+            close (server_socket);
 
         /* close the control pipe fd */
-        close (control_fd);
+        if(control_fd!=-1)
+            close (control_fd);
 
         if( c->dialing[0] )
         {


### PR DESCRIPTION
with flapping tunnels and calls.
in short:
- the largest leaks are caused by not recycling the buffer in the network thread
- many small leaks when calls and tunnels are destroyed due to oldptyconf
- moved all arrays to the bottom of the tunnel structure to spot more easily buffer overflows
- fixed accessing already freed memory when destroying the pppd calls of a tunnel