### PR TITLE
Small hack for some IPS

### DIFF
--- a/file.c
+++ b/file.c
@@ -351,6 +351,14 @@ int set_speed (char *word, char *value, int context, void *item)
     return 0;
 }
 
+int set_host_ip_dump_file(char *word, char *value, int context, void *item)
+{
+    int len = strlen(value) + 1;
+    host_ip_dump_file = (char*)malloc(len);
+    strcpy(host_ip_dump_file, value);
+    return 0;
+}
+
 int set_rmax (char *word, char *value, int context, void *item)
 {
     if (atoi (value) < 1)
@@ -1537,5 +1545,6 @@ struct keyword words[] = {
     {"tx bps", &set_speed},
     {"rx bps", &set_speed},
     {"bps", &set_speed},
+    {"host ip dump file", &set_host_ip_dump_file},
     {NULL, NULL}
 };

--- a/l2tp.h
+++ b/l2tp.h
@@ -237,6 +237,7 @@ extern void control_xmit (void *);
 extern int ppd;
 extern int switch_io;           /* jz */
 extern int control_fd;
+extern char *host_ip_dump_file;
 #ifdef USE_KERNEL
 extern int kernel_support;
 extern int connect_pppol2tp (struct tunnel *t);


### PR DESCRIPTION
With some ISPs (e.g. Russian "Beeline"), gethostbyname(lns) != $PPP_REMOTE, so you can't add route to it.