### PR TITLE
PPP frames fragmentation handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.o
 *~
 *.bak
-l2tpd
+xl2tpd
+xl2tpd-control
+pfc

--- a/call.c
+++ b/call.c
@@ -88,7 +88,7 @@ void add_payload_hdr (struct tunnel *t, struct call *c, struct buffer *buf)
 /*	c->rbit=0; */
 }
 
-int read_packet (struct buffer *buf, int fd, int convert)
+int read_packet (struct buffer *buf, int fd)
 {
     unsigned char c;
     unsigned char escape = 0;
@@ -164,31 +164,18 @@ int read_packet (struct buffer *buf, int fd, int convert)
                 return -EINVAL;
             }
 
-            if (convert)
-            {
-	      if (buf->len >= 2) {
-		/* must be the end, drop the FCS */
-		buf->len -= 2;
-	      }
-	      else if (buf->len == 1) {
-		/* Do nothing, just return the single character*/
-	      }
-	      else {
-		/* if the buffer is empty, then we have the beginning
-		 * of a packet, not the end
-		 */
-		break;
-	      }
-	    }
-            else
-            {
-		/* if there is space, then insert the byte */
-                if (buf->len < buf->maxlen)
-                {
-                    *p = c;
-                    p++;
-                    buf->len++;
-                }
+            if (buf->len >= 2) {
+              /* must be the end, drop the FCS */
+              buf->len -= 2;
+            }
+            else if (buf->len == 1) {
+              /* Do nothing, just return the single character*/
+            }
+            else {
+              /* if the buffer is empty, then we have the beginning
+               * of a packet, not the end
+               */
+              break;
             }
 
 	    /* return what we have now */
@@ -196,13 +183,10 @@ int read_packet (struct buffer *buf, int fd, int convert)
 
         case PPP_ESCAPE:
             escape = PPP_TRANS;
-            if (convert)
-                break;
+            break;
 
-	    /* fall through */
         default:
-            if (convert)
-                c ^= escape;
+            c ^= escape;
             escape = 0;
             if (buf->len < buf->maxlen)
             {

--- a/call.c
+++ b/call.c
@@ -88,15 +88,16 @@ void add_payload_hdr (struct tunnel *t, struct call *c, struct buffer *buf)
 /*	c->rbit=0; */
 }
 
-int read_packet (struct buffer *buf, struct call *c)
+int read_packet (struct call *c)
 {
+    struct buffer *buf = c->ppp_buf;
     unsigned char ch;
     unsigned char escape = 0;
     unsigned char *p;
     int res;
     int errors = 0;
 
-    p = buf->start;
+    p = buf->start + buf->len;
     while (1)
     {
         if (c->rbuf_pos >= c->rbuf_max)
@@ -392,6 +393,7 @@ void destroy_call (struct call *c)
 /*	if (c->dethrottle) deschedule(c->dethrottle); */
     if (c->zlb_xmit)
         deschedule (c->zlb_xmit);
+    toss(c->ppp_buf);
 
 #ifdef IP_ALLOCATION
     if (c->addr)
@@ -536,6 +538,7 @@ struct call *new_call (struct tunnel *parent)
     tmp->fd = -1;
     tmp->rbuf_pos = 0;
     tmp->rbuf_max = 0;
+    tmp->ppp_buf = new_payload (parent->peer);
     tmp->oldptyconf = malloc (sizeof (struct termios));
     tmp->pnu = 0;
     tmp->cnu = 0;

--- a/call.h
+++ b/call.h
@@ -70,6 +70,9 @@ struct call
      */
     struct tunnel *container;   /* Tunnel we belong to */
     int fd;                     /* File descriptor for pty */
+    unsigned char rbuf[MAX_RECV_SIZE];  /* pty read buffer */
+    int rbuf_pos;               /* Read buffer position */
+    int rbuf_max;               /* Read buffer data length */
     struct termios *oldptyconf;
     int die;
     int nego;                   /* Show negotiation? */

--- a/call.h
+++ b/call.h
@@ -73,6 +73,7 @@ struct call
     unsigned char rbuf[MAX_RECV_SIZE];  /* pty read buffer */
     int rbuf_pos;               /* Read buffer position */
     int rbuf_max;               /* Read buffer data length */
+    struct buffer *ppp_buf;     /* Packet readed from pty */
     struct termios *oldptyconf;
     int die;
     int nego;                   /* Show negotiation? */

--- a/l2tp.h
+++ b/l2tp.h
@@ -231,7 +231,7 @@ extern void destroy_tunnel (struct tunnel *);
 extern struct buffer *new_payload (struct sockaddr_in);
 extern void recycle_payload (struct buffer *, struct sockaddr_in);
 extern void add_payload_hdr (struct tunnel *, struct call *, struct buffer *);
-extern int read_packet (struct buffer *, struct call *);
+extern int read_packet (struct call *);
 extern void udp_xmit (struct buffer *buf, struct tunnel *t);
 extern void control_xmit (void *);
 extern int ppd;

--- a/l2tp.h
+++ b/l2tp.h
@@ -231,7 +231,7 @@ extern void destroy_tunnel (struct tunnel *);
 extern struct buffer *new_payload (struct sockaddr_in);
 extern void recycle_payload (struct buffer *, struct sockaddr_in);
 extern void add_payload_hdr (struct tunnel *, struct call *, struct buffer *);
-extern int read_packet (struct buffer *, int, int);
+extern int read_packet (struct buffer *, int);
 extern void udp_xmit (struct buffer *buf, struct tunnel *t);
 extern void control_xmit (void *);
 extern int ppd;

--- a/l2tp.h
+++ b/l2tp.h
@@ -20,6 +20,8 @@ typedef unsigned long long _u64;
 #define _L2TP_H
 
 #define MAXSTRLEN 120           /* Maximum length of common strings */
+                                /* FIXME: MAX_RECV_SIZE, what is it? */
+#define MAX_RECV_SIZE 4096      /* Biggest packet we'll accept */
 
 #include <netinet/in.h>
 #include <termios.h>
@@ -124,8 +126,6 @@ struct payload_hdr
 #define MIN_PAYLOAD_HDR_LEN 6
 
 #define UDP_LISTEN_PORT  1701
-                                /* FIXME: MAX_RECV_SIZE, what is it? */
-#define MAX_RECV_SIZE 4096      /* Biggest packet we'll accept */
 
 #define OUR_L2TP_VERSION 0x100  /* We support version 1, revision 0 */
 

--- a/l2tp.h
+++ b/l2tp.h
@@ -231,7 +231,7 @@ extern void destroy_tunnel (struct tunnel *);
 extern struct buffer *new_payload (struct sockaddr_in);
 extern void recycle_payload (struct buffer *, struct sockaddr_in);
 extern void add_payload_hdr (struct tunnel *, struct call *, struct buffer *);
-extern int read_packet (struct buffer *, int);
+extern int read_packet (struct buffer *, struct call *);
 extern void udp_xmit (struct buffer *buf, struct tunnel *t);
 extern void control_xmit (void *);
 extern int ppd;

--- a/network.c
+++ b/network.c
@@ -666,7 +666,7 @@ void network_thread ()
                     recycle_payload (buf, sc->container->peer);
 
                     while ((result =
-                            read_packet (buf, sc->fd, SYNC_FRAMING)) > 0)
+                            read_packet (buf, sc->fd)) > 0)
                     {
                         add_payload_hdr (sc->container, sc, buf);
                         if (gconfig.packet_dump)

--- a/network.c
+++ b/network.c
@@ -665,8 +665,7 @@ void network_thread ()
                     int result;
                     recycle_payload (buf, sc->container->peer);
 
-                    while ((result =
-                            read_packet (buf, sc->fd)) > 0)
+                    while ((result = read_packet (buf, sc)) > 0)
                     {
                         add_payload_hdr (sc->container, sc, buf);
                         if (gconfig.packet_dump)

--- a/network.c
+++ b/network.c
@@ -664,26 +664,7 @@ void network_thread ()
                     /* Got some payload to send */
                     int result;
                     recycle_payload (buf, sc->container->peer);
-/*
-#ifdef DEBUG_FLOW_MORE
-                    l2tp_log (LOG_DEBUG, "%s: rws = %d, pSs = %d, pLr = %d\n",
-                         __FUNCTION__, sc->rws, sc->pSs, sc->pLr);
-#endif
-		    if ((sc->rws>0) && (sc->pSs > sc->pLr + sc->rws) && !sc->rbit) {
-#ifdef DEBUG_FLOW
-						log(LOG_DEBUG, "%s: throttling payload (call = %d, tunnel = %d, Lr = %d, Ss = %d, rws = %d)!\n",__FUNCTION__,
-								 sc->cid, sc->container->tid, sc->pLr, sc->pSs, sc->rws); 
-#endif
-						sc->throttle = -1;
-						We unthrottle in handle_packet if we get a payload packet, 
-						valid or ZLB, but we also schedule a dethrottle in which
-						case the R-bit will be set
-						FIXME: Rate Adaptive timeout? 						
-						tv.tv_sec = 2;
-						tv.tv_usec = 0;
-						sc->dethrottle = schedule(tv, dethrottle, sc); 					
-					} else */
-/*					while ((result=read_packet(buf,sc->fd,sc->frame & SYNC_FRAMING))>0) { */
+
                     while ((result =
                             read_packet (buf, sc->fd, SYNC_FRAMING)) > 0)
                     {

--- a/network.c
+++ b/network.c
@@ -663,14 +663,13 @@ void network_thread ()
                 {
                     /* Got some payload to send */
                     int result;
-                    recycle_payload (buf, sc->container->peer);
 
-                    while ((result = read_packet (buf, sc)) > 0)
+                    while ((result = read_packet (sc)) > 0)
                     {
-                        add_payload_hdr (sc->container, sc, buf);
+                        add_payload_hdr (sc->container, sc, sc->ppp_buf);
                         if (gconfig.packet_dump)
                         {
-                            do_packet_dump (buf);
+                            do_packet_dump (sc->ppp_buf);
                         }
 
 
@@ -680,10 +679,10 @@ void network_thread ()
                             deschedule (sc->zlb_xmit);
                             sc->zlb_xmit = NULL;
                         }
-                        sc->tx_bytes += buf->len;
+                        sc->tx_bytes += sc->ppp_buf->len;
                         sc->tx_pkts++;
-                        udp_xmit (buf, st);
-                        recycle_payload (buf, sc->container->peer);
+                        udp_xmit (sc->ppp_buf, st);
+                        recycle_payload (sc->ppp_buf, sc->container->peer);
                     }
                     if (result != 0)
                     {


### PR DESCRIPTION
Hello,

this change set improves the fragmented frame handling, during reading frame from pty. Without fragmentation support, at least under OpenBSD, you can not send frames larger than 1024 bytes.

Changes tested with xl2tpd-1.3.1 under OpenBSD and then rebased on top of master branch.
