### PR TITLE
Devel fix

### DIFF
--- a/doc/xl2tpd.8
+++ b/doc/xl2tpd.8
@@ -20,6 +20,11 @@ This option prevents xl2tpd from detaching from the terminal and
 daemonizing.  
 
 .TP 
+.B -l
+This option tells xl2tpd to use syslog for logging even when \fB\-D\fR
+was specified.
+
+.TP
 .B -c <config file>
 Tells xl2tpd to use an alternate config file.  Default is
 /etc/xl2tpd/xl2tpd.conf. Fallback configuration file is

--- a/file.h
+++ b/file.h
@@ -151,6 +151,7 @@ struct global
     char pidfile[STRLEN];       /* File containing the pid number*/
     char controlfile[STRLEN];   /* Control file name (named pipe) */
     int daemon;                 /* Use daemon mode? */
+    int syslog;                 /* Use syslog for logging? */
     int accesscontrol;          /* Use access control? */
     int forceuserspace;         /* Force userspace? */
     int packet_dump;		/* Dump (print) all packets? */

--- a/misc.c
+++ b/misc.c
@@ -57,7 +57,7 @@ void l2tp_log (int level, const char *fmt, ...)
     vsnprintf (buf, sizeof (buf), fmt, args);
     va_end (args);
     
-    if(gconfig.daemon) {
+    if(gconfig.syslog) {
 	init_log();
 	SYSLOG_CALL( syslog (level, "%s", buf) );
     } else {

--- a/xl2tpd-control.c
+++ b/xl2tpd-control.c
@@ -51,6 +51,7 @@ struct command_t
     char *name;
     int (*handler) (FILE*, char* tunnel, int optc, char *optv[]);
     int requires_tunnel;
+    char *help;
 };
 
 int command_add_lac (FILE*, char* tunnel, int optc, char *optv[]);
@@ -65,10 +66,24 @@ int command_available (FILE*, char* tunnel, int optc, char *optv[]);
 
 struct command_t commands[] = {
     /* Keep this command mapping for backwards compat */
-    {"add", &command_add_lac, TUNNEL_REQUIRED},
-    {"connect", &command_connect_lac, TUNNEL_REQUIRED},
-    {"disconnect", &command_disconnect_lac, TUNNEL_REQUIRED},
-    {"remove", &command_remove_lac, TUNNEL_REQUIRED},
+    {"add", &command_add_lac, TUNNEL_REQUIRED,
+        "\tadd\tadds new or modify existing lac configuration.\n"
+        "\t\tConfiguration must be specified as command options in\n"
+        "\t\t<key>=<value> pairs format.\n"
+        "\t\tSee available options in xl2tpd.conf(5)\n"
+    },
+    {"connect", &command_connect_lac, TUNNEL_REQUIRED,
+        "\tconnect\ttries to activate the tunnel.\n"
+        "\t\tUsername and secret for the tunnel can be passed as\n"
+        "\t\tcommand options.\n"
+    },
+    {"disconnect", &command_disconnect_lac, TUNNEL_REQUIRED,
+        "\tdisconnect\tdisconnects the tunnel.\n"
+    },
+    {"remove", &command_remove_lac, TUNNEL_REQUIRED,
+        "\tremove\tremoves lac configuration from xl2tpd.\n"
+        "\t\txl2tpd disconnects the tunnel before removing.\n"
+    },
 
     /* LAC commands */
     {"add-lac", &command_add_lac, TUNNEL_REQUIRED},
@@ -77,7 +92,9 @@ struct command_t commands[] = {
     {"remove-lac", &command_remove_lac, TUNNEL_REQUIRED},
 
     /* LNS commands */
-    {"add-lns", &command_add_lns, TUNNEL_REQUIRED},
+    {"add-lns", &command_add_lns, TUNNEL_REQUIRED,
+        "\tadd-lns\tadds new or modify existing lns configuration.\n"
+    },
     {"remove-lns", &command_remove_lns, TUNNEL_REQUIRED},
 
     /* Generic commands */
@@ -89,36 +106,44 @@ struct command_t commands[] = {
 
 void usage()
 {
+    int i;
+
     printf ("\nxl2tpd server version %s\n", SERVER_VERSION);
     printf ("Usage: xl2tpd-control [-c <PATH>] <command> <tunnel name> [<COMMAND OPTIONS>]\n"
             "\n"
             "    -c\tspecifies xl2tpd control file\n"
             "    -d\tspecify xl2tpd-control to run in debug mode\n"
             "--help\tshows extended help\n"
-            "Available commands: add, connect, disconnect, remove, add-lns\n"
     );
+
+    printf ("Available commands: ");
+    for (i = 0; commands[i].name; i++) {
+        struct command_t *command = &commands[i];
+        int last = command[1].name == NULL;
+
+        printf ("%s%s", command->name, !last ? ", " : "\n");
+    }
 }
 
 void help()
 {
+    int i;
+
     usage();
     printf (
         "\n"
         "Commands help:\n"
-        "\tadd\tadds new or modify existing lac configuration.\n"
-        "\t\tConfiguration must be specified as command options in\n"
-        "\t\t<key>=<value> pairs format.\n"
-        "\t\tSee available options in xl2tpd.conf(5)\n"
-        "\tconnect\ttries to activate the tunnel.\n"
-        "\t\tUsername and secret for the tunnel can be passed as\n"
-        "\t\tcommand options.\n"
-        "\tdisconnect\tdisconnects the tunnel.\n"
-        "\tremove\tremoves lac configuration from xl2tpd.\n"
-        "\t\txl2tpd disconnects the tunnel before removing.\n"
-        "\n"
-        "\tadd-lns\tadds new or modify existing lns configuration.\n"
-        "See xl2tpd-control man page for more help\n"
     );
+
+    for (i = 0; commands[i].name; i++) {
+        struct command_t *command = &commands[i];
+
+        if (!command->help)
+            continue;
+        printf ("%s", command->help);
+    }
+    /*FIXME Ha! there is currently no manpage for xl2tpd-control */
+    printf ("See xl2tpd-control man page for more help\n");
 }
 
 void cleanup(void)

--- a/xl2tpd-control.c
+++ b/xl2tpd-control.c
@@ -246,7 +246,7 @@ int main (int argc, char *argv[])
     print_error (DEBUG_LEVEL, "command to be passed:\n%s\n", buf);
 
     /* try to open control file for writing */
-    int control_fd = open (control_filename, O_WRONLY, 0600);
+    int control_fd = open (control_filename, O_WRONLY | O_NONBLOCK, 0600);
     if (control_fd < 0)
     {
         int errorno = errno;
@@ -264,6 +264,14 @@ int main (int argc, char *argv[])
                 control_filename, strerror (errorno));
         }
         return -1;
+    }
+
+    /* turn off O_NONBLOCK */
+    if (fcntl (control_fd, F_SETFL, O_WRONLY) == -1) {
+        print_error (ERROR_LEVEL,
+            "Can not turn off nonblocking mode for control_fd: %s\n",
+            strerror(errno));
+        return -2;
     }
     
     /* pass command to control pipe */

--- a/xl2tpd-control.c
+++ b/xl2tpd-control.c
@@ -164,7 +164,6 @@ int main (int argc, char *argv[])
     {
         control_filename = strdup (CONTROL_PIPE);
     }
-    print_error (DEBUG_LEVEL, "set control filename to %s\n", control_filename);    
 
     /* parse command name */
     for (command = commands; command->name; command++)
@@ -176,10 +175,7 @@ int main (int argc, char *argv[])
         }
     }
     
-    if (command->name)
-    {
-        print_error (DEBUG_LEVEL, "get command %s\n", command->name);
-    } else {
+    if (!command->name) {
         print_error (ERROR_LEVEL, "error: no such command %s\n", argv[i]);
         return -1;
     }
@@ -303,7 +299,8 @@ int main (int argc, char *argv[])
     int command_result_code = read_result (
         result_fd, rbuf, CONTROL_PIPE_MESSAGE_SIZE
     );
-    printf ("%s", rbuf);
+    /* rbuf contains a newline, make it double to form a boundary. */
+    print_error (DEBUG_LEVEL, "command response: \n%s\n", rbuf);
     
     return command_result_code;
 }
@@ -313,6 +310,7 @@ void print_error (int level, const char *fmt, ...)
     if (level > log_level) return;
     va_list args;
     va_start (args, fmt);
+    fprintf (stderr, "xl2tpd-control: ");
     vfprintf (stderr, fmt, args);
     va_end (args);
 }

--- a/xl2tpd-control.c
+++ b/xl2tpd-control.c
@@ -10,6 +10,8 @@
  *
  */
  
+#define _GNU_SOURCE
+
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -1040,7 +1040,7 @@ int control_handle_available(FILE* resf, char* bufp){
         lns_count++;
     }                                               
 
-    write_res (resf, "%02i AVAILABLE lns.cout=%d\n", 0, lns_count);
+    write_res (resf, "%02i AVAILABLE lns.count=%d\n", 0, lns_count);
 
     lac  = laclist;
     int lac_count = 0;
@@ -1054,7 +1054,7 @@ int control_handle_available(FILE* resf, char* bufp){
     if(deflac){
         write_res (resf, "%02i AVAILABLE lac.%d.name=%s\n", 0, lac_count, deflac->entname);
         lac_count++;
-    }                                               
+    }
 
     write_res (resf, "%02i AVAILABLE lac.count=%d\n", 0, lac_count);
     return 1;

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -1595,7 +1595,7 @@ void do_control ()
 void usage(void) {
     printf("\nxl2tpd version:  %s\n", SERVER_VERSION);
     printf("Usage: xl2tpd [-c <config file>] [-s <secret file>] [-p <pid file>]\n"
-            "              [-C <control file>] [-D]\n"
+            "              [-C <control file>] [-D] [-l]\n"
             "              [-v, --version]\n");
     printf("\n");
     exit(1);
@@ -1606,6 +1606,7 @@ void init_args(int argc, char *argv[])
     int i=0;
 
     gconfig.daemon=1;
+    gconfig.syslog=-1;
     memset(gconfig.altauthfile,0,STRLEN);
     memset(gconfig.altconfigfile,0,STRLEN);
     memset(gconfig.authfile,0,STRLEN);
@@ -1643,6 +1644,9 @@ void init_args(int argc, char *argv[])
         else if (! strncmp(argv[i],"-D",2)) {
             gconfig.daemon=0;
         }
+        else if (! strncmp(argv[i],"-l",2)) {
+            gconfig.syslog=1;
+        }
         else if (! strncmp(argv[i],"-s",2)) {
             if(++i == argc)
                 usage();
@@ -1668,6 +1672,13 @@ void init_args(int argc, char *argv[])
             usage();
         }
     }
+
+    /*
+     * defaults to syslog if no log facility was explicitly
+     * specified and we are about to daemonize
+     */
+    if (gconfig.syslog < 0)
+        gconfig.syslog = gconfig.daemon;
 }
 
 

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -1414,20 +1414,18 @@ int control_handle_lac_add_modify(FILE* resf, char* bufp){
             return 0;
         lac = lac->next;
     }
+
+    /* nothing found, create new lac */
+    lac = new_lac ();
     if (!lac)
     {
-        /* nothing found, create new lac */
-        lac = new_lac ();
-        if (!lac)
-        {
-            write_res (resf,
-                    "%02i Could't create new lac: no memory\n", 2);
-            l2tp_log (LOG_CRIT,
-                    "%s: Couldn't create new lac\n", __FUNCTION__);
-            return 0;
-        }
-        create_new_lac = 1;
+        write_res (resf,
+                "%02i Could't create new lac: no memory\n", 2);
+        l2tp_log (LOG_CRIT,
+                "%s: Couldn't create new lac\n", __FUNCTION__);
+        return 0;
     }
+    create_new_lac = 1;
     strncpy (lac->entname, tunstr, sizeof (lac->entname));
 
     if (parse_one_line_lac (bufp, lac))

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -382,7 +382,6 @@ int start_pppd (struct call *c, struct ppp_opts *opts)
     /* char a, b; */
     char tty[512];
     char *stropt[80];
-    struct ppp_opts *p;
 #ifdef USE_KERNEL
     struct sockaddr_pppol2tp sax;
     int flags;
@@ -396,16 +395,7 @@ int start_pppd (struct call *c, struct ppp_opts *opts)
     struct call *sc;
     struct tunnel *st;
 
-    p = opts;
     stropt[0] = strdup (PPPD);
-    while (p)
-    {
-        stropt[pos] = (char *) malloc (strlen (p->option) + 1);
-        strncpy (stropt[pos], p->option, strlen (p->option) + 1);
-        pos++;
-        p = p->next;
-    }
-    stropt[pos] = NULL;
     if (c->pppd > 0)
     {
         l2tp_log(LOG_WARNING, "%s: PPP already started on call!\n", __FUNCTION__);
@@ -467,7 +457,6 @@ int start_pppd (struct call *c, struct ppp_opts *opts)
         snprintf (stropt[pos], 10, "%d", c->ourcid);
             pos++;
        }
-        stropt[pos] = NULL;
     }
     else
 #endif
@@ -497,6 +486,17 @@ int start_pppd (struct call *c, struct ppp_opts *opts)
             return -EINVAL;
         }
         stropt[pos++] = strdup(tty);
+    }
+
+    {
+        struct ppp_opts *p = opts;
+        int maxn_opts = sizeof(stropt) / sizeof(stropt[0]) - 1;
+        while (p && pos < maxn_opts)
+        {
+            stropt[pos] = strdup (p->option);
+            pos++;
+            p = p->next;
+        }
         stropt[pos] = NULL;
     }
 

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -1552,7 +1552,6 @@ void do_control ()
             /*FIXME: check quotes to allow filenames with spaces?
               (do not forget quotes escaping to allow filenames with quotes)*/
 
-            /*FIXME: write to res_filename may cause SIGPIPE, need to catch it*/
             resf = fopen (res_filename, "w");
             if (!resf) {
                 l2tp_log (LOG_DEBUG, "%s: Can't open result file %s\n",
@@ -1812,6 +1811,7 @@ void init (int argc,char *argv[])
     signal (SIGCHLD, &sigchld_handler);
     signal (SIGUSR1, &sigusr1_handler);
     signal (SIGHUP, &sighup_handler);
+    signal (SIGPIPE, SIG_IGN);
     init_scheduler ();
 
     unlink(gconfig.controlfile);

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -1583,6 +1583,8 @@ void do_control ()
         if (resf)
         {
             fclose (resf);
+            /* unlink it anyway to prevent leftover a regular file. */
+            unlink(res_filename);
         }
     }
 


### PR DESCRIPTION
This is a patch set formed while working on xl2tpd with OpenWrt. It mainly tries to cleanup xl2tpd-control a bit, plus a few cosmetic changes. Hope this helps.

Changes since pull request https://github.com/xelerance/xl2tpd/pull/60

 - In commit "...check end-of-file", also check the case errno==EINTR and continue reading in that case
 - More verbose commit message in commit "... prevent leftover a regular file"
 - Placed the help text for add-lns command to the correct position in commit "... show all commands in --help".
 - Introduced a new commit "... remove unnecessary NULL check on lac"
