### PR TITLE
Devel fix valgrind

### DIFF
--- a/call.c
+++ b/call.c
@@ -480,12 +480,9 @@ void destroy_call (struct call *c)
         }
     }
     if(c->oldptyconf)
-		free(c->oldptyconf);
+        free(c->oldptyconf);
 
-    /* This is totally the wrong place to free the memory.
-     * It's already being done by the upper layers.
-     free (c);
-   */
+    free (c);
 }
 
 

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -1504,6 +1504,7 @@ int control_handle_lac_remove(FILE* resf, char* bufp){
     if (lac->t)
     {
         lac_disconnect (lac->t->ourtid);
+        lac->t->lac = NULL;
     }
     // removes lac from laclist
     if (prev_lac == NULL)

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -688,10 +688,8 @@ void destroy_tunnel (struct tunnel *t)
         close (t->pppox_fd);
     if (t->udp_fd > -1 )
         close (t->udp_fd);
+    destroy_call (me);
     free (t);
-	if(me->oldptyconf)
-		free(me->oldptyconf);
-    free (me);
 }
 
 struct tunnel *l2tp_call (char *host, int port, struct lac *lac,

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -1506,6 +1506,16 @@ int control_handle_lac_remove(FILE* resf, char* bufp){
         lac_disconnect (lac->t->ourtid);
         lac->t->lac = NULL;
     }
+    if (lac->lns)
+    {
+        struct host *t, *h = lac->lns;
+        while (h)
+        {
+            t = h->next;
+            free(h);
+            h = t;
+        }
+    }
     // removes lac from laclist
     if (prev_lac == NULL)
         laclist = lac->next;

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -1503,6 +1503,16 @@ int control_handle_lac_remove(FILE* resf, char* bufp){
     {
         lac_disconnect (lac->t->ourtid);
         lac->t->lac = NULL;
+        lac->t->self->lac = NULL;
+    }
+    if (lac->c)
+    {
+        struct call *c = lac->c;
+        while (c)
+        {
+            c->lac = NULL;
+            c = c->next;
+        }
     }
     if (lac->lns)
     {


### PR DESCRIPTION
This series started because a few memory corruption was observed when running xl2tpd under OpenWrt causing many segmentation fault errors.

The series was made on a x86_64 host with help of valgrind.

```
sudo valgrind -v --tool=memcheck --leak-check=full --log-file=valgrind.xl2tpd ./xl2tpd -C l2tp-control -c xl2tpd.conf -D -p xl2tpd.pid
```

Then tested with xl2tpd-control by adding and removing lac to false lns.

```
while true; do
sudo ./xl2tpd-control -c ./l2tp-control add l2tp-xxxxx pppoptfile=$(pwd)/options.xl2tpd lns='99.8.99.8'
sudo ./xl2tpd-control -c ./l2tp-control connect l2tp-xxxxx
sleep 0.5
sudo ./xl2tpd-control -c ./l2tp-control remove l2tp-xxxxx
sleep 0.5
done
```
