### PR TITLE
Fix paths in man pages

### DIFF
--- a/doc/l2tp-secrets.5
+++ b/doc/l2tp-secrets.5
@@ -25,7 +25,7 @@ length requirement, however.
 
 .SH "FILES"
 
-\fB\fR/etc/xl2tpd/xl2tpd.conf \fB\fR/etc/lx2tpd/l2tp\-secrets 
+\fB\fR/etc/xl2tpd/xl2tpd.conf \fB\fR/etc/xl2tpd/l2tp\-secrets 
 \fB\fR/var/run/xl2tpd/l2tp\-control
 .SH "BUGS"
 

--- a/doc/xl2tpd.8
+++ b/doc/xl2tpd.8
@@ -44,7 +44,7 @@ Tells xl2tpd to use an alternate control file.  Default is
 .SH "FILES"
 
 \fB\fR/etc/xl2tpd/xl2tpd.conf \fB\fR/etc/xl2tpd/l2tp\-secrets 
-\fB\fR/var/run/l2tp\-control
+\fB\fR/var/run/xl2tpd/l2tp\-control
 .SH "BUGS"
 
 Please address bugs and comment to xl2tpd@lists.xelerance.com

--- a/doc/xl2tpd.conf.5
+++ b/doc/xl2tpd.conf.5
@@ -6,7 +6,7 @@ The xl2tpd.conf file contains configuration information for xl2tpd, the implemen
 
 The configuration file is composed of sections and parameters. Each section
 has a given name which will be used when using the configuration FIFO 
-(normaly /var/run/l2tp\-control). See xl2tpd.8  for more details.
+(normaly /var/run/xl2tpd/l2tp\-control). See xl2tpd.8  for more details.
 
 The specific given name 
 .B default
@@ -15,7 +15,7 @@ will specify parameters applicables for all the following sections.
 .TP 
 .B auth file
 Specify where to find the authentication file used to authenticate
-l2tp tunnels. The default is /etc/l2tpd/l2tp\-secrets.
+l2tp tunnels. The default is /etc/xl2tpd/l2tp\-secrets.
 
 .TP 
 .B ipsec saref


### PR DESCRIPTION
I found typo and old file paths in man pages.