### PR TITLE
Fix null referencing when removing lac

### DIFF
--- a/call.c
+++ b/call.c
@@ -371,7 +371,7 @@ void call_close (struct call *c)
              c->ourcid, IPADDY (c->container->peer.sin_addr));
     }
     /*
-       * Note that we're in the process of closing now
+     * Note that we're in the process of closing now
      */
     c->closing = -1;
 }

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -1502,8 +1502,11 @@ int control_handle_lac_remove(FILE* resf, char* bufp){
     if (lac->t)
     {
         lac_disconnect (lac->t->ourtid);
-        lac->t->lac = NULL;
-        lac->t->self->lac = NULL;
+        /* lac->t could have been cleared */
+        if (lac->t) {
+            lac->t->lac = NULL;
+            lac->t->self->lac = NULL;
+	}
     }
     if (lac->c)
     {


### PR DESCRIPTION
This will prevent SIGSEGV when doing lac remove.  The order of events
were as follows

 1. A new lac was added
 2. Maxium retries exceeded so we call_close() and set "c->closing = -1"
 3. A lac removal request was received
 4. lac_disconnect(lac->t) was called
     1. call_close(t->self) was called
     2. Since c->closing was set before, so this time we call
        destroy_tunnel(c->container) which set "t->lac = NULL"
 5. lac->t->lac = NULL resulted in SIGSEGV

Relevant syslog output

    xl2tpd[17747]: do_control: Got message @/var/run/xl2tpd/xl2tpd-control-17755.out c l2tp-sankuai (56 bytes long)
    xl2tpd[17747]: ourtid = 49201, entropy_buf = c031
    xl2tpd[17747]: Connecting to host 103.37.140.22, port 1701
    xl2tpd[17747]: trying to send control packet to 49201
    xl2tpd[17747]: control_xmit: Scheduling and transmitting packet 0
    xl2tpd[17747]: trying to send control packet to 49201
    xl2tpd[17747]: control_xmit: Scheduling and transmitting packet 0
    xl2tpd[17747]: trying to send control packet to 49201
    xl2tpd[17747]: control_xmit: Scheduling and transmitting packet 0
    xl2tpd[17747]: trying to send control packet to 49201
    xl2tpd[17747]: control_xmit: Scheduling and transmitting packet 0
    xl2tpd[17747]: trying to send control packet to 49201
    xl2tpd[17747]: control_xmit: Scheduling and transmitting packet 0
    xl2tpd[17747]: trying to send control packet to 49201
    xl2tpd[17747]: Maximum retries exceeded for tunnel 49201.  Closing.
    xl2tpd[17747]: call_close: enqueing close message for tunnel
    xl2tpd[17747]: trying to send control packet to 49201
    xl2tpd[17747]: control_xmit: Scheduling and transmitting packet 1
    xl2tpd[17747]: Connection 0 closed to 103.37.140.22, port 1701 (Timeout)
    xl2tpd[17747]: do_control: Got message @/var/run/xl2tpd/xl2tpd-control-17759.out r l2tp-sankuai (56 bytes long)
    xl2tpd[17747]: Disconnecting from 103.37.140.22, Local: 49201, Remote: 0
    xl2tpd[17747]: call_close: Descheduling event
    xl2tpd[17747]: call_close: Actually closing tunnel 49201
    netifd: sankuai (17756): xl2tpd-control: Remove l2tp-sankuai failed

Relevant valgrind output removing lac after 5 seconds since adding it

    ==25853== LEAK SUMMARY:
    ==25853==    definitely lost: 0 bytes in 0 blocks
    ==25853==    indirectly lost: 0 bytes in 0 blocks
    ==25853==      possibly lost: 0 bytes in 0 blocks
    ==25853==    still reachable: 6,208 bytes in 7 blocks
    ==25853==         suppressed: 0 bytes in 0 blocks
    ==25853== Reachable blocks (those to which a pointer was found) are not shown.
    ==25853== To see them, rerun with: --leak-check=full --show-reachable=yes
    ==25853==
    ==25853== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 4 from 4)
    ==25853==
    ==25853== 1 errors in context 1 of 1:
    ==25853== Invalid write of size 8
    ==25853==    at 0x403639: control_handle_lac_remove (in /home/yousong/git-repo/xl2tpd/xl2tpd)
    ==25853==    by 0x40467D: do_control (in /home/yousong/git-repo/xl2tpd/xl2tpd)
    ==25853==    by 0x40E891: network_thread (in /home/yousong/git-repo/xl2tpd/xl2tpd)
    ==25853==    by 0x401C35: main (in /home/yousong/git-repo/xl2tpd/xl2tpd)
    ==25853==  Address 0xb0 is not stack'd, malloc'd or (recently) free'd