### PR TITLE
Fix #98 by checking if a valid PID is being killed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ OBJS=xl2tpd.o pty.o misc.o control.o avp.o call.o network.o avpsend.o scheduler.
 SRCS=${OBJS:.o=.c} ${HDRS}
 CONTROL_SRCS=xl2tpd-control.c
 #LIBS= $(OSLIBS) # -lefence # efence for malloc checking
+LDLIBS= -lm
 EXEC=xl2tpd
 CONTROL_EXEC=xl2tpd-control
 


### PR DESCRIPTION
When `start_ppd` fails, a PID of -1 is used in the `kill` command, causing catastrophic events.