### PR TITLE
Removing -fno-builtin from CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ OSFLAGS+= -DUSE_KERNEL
 
 IPFLAGS?= -DIP_ALLOCATION
 
-CFLAGS+= $(DFLAGS) -Os -fno-builtin -Wall -DSANITY $(OSFLAGS) $(IPFLAGS)
+CFLAGS+= $(DFLAGS) -Os -Wall -DSANITY $(OSFLAGS) $(IPFLAGS)
 HDRS=l2tp.h avp.h misc.h control.h call.h scheduler.h file.h aaa.h md5.h
 OBJS=xl2tpd.o pty.o misc.o control.o avp.o call.o network.o avpsend.o scheduler.o file.o aaa.o md5.o
 SRCS=${OBJS:.o=.c} ${HDRS}


### PR DESCRIPTION
Advantage of -no-builtin
It potentially makes debuggin easier (by allowine one to set breakpoints).

Disadvantags of -no-builtin
-Wformat info gets suppressed

In the end, it is likely that this shoudl be removed