### PR TITLE
Fixing minor typo and spelling mistake in xl2tpd.conf.5, l2tpd.conf.sample and code

### DIFF
--- a/aaa.c
+++ b/aaa.c
@@ -111,7 +111,7 @@ unsigned int get_addr (struct iprange *ipr)
             for (x = ntohl (ipr->start); x <= ntohl (ipr->end); x++)
             {
                 /* Found an IP in an ALLOW range, check to be sure it is
-                   consistant through the remaining regions */
+                   consistent through the remaining regions */
                 if (!ip_used (x))
                 {
                     status = SENSE_ALLOW;
@@ -434,7 +434,7 @@ void encrypt_avp (struct buffer *buf, _u16 len, struct tunnel *t)
 int decrypt_avp (char *buf, struct tunnel *t)
 {
     /* Decrypts a hidden AVP pointed to by buf.  The
-       new header will be exptected to be two characters
+       new header will be expected to be two characters
        offset from the old */
     int cnt = 0;
     int len, olen, flags;

--- a/avp.c
+++ b/avp.c
@@ -130,7 +130,7 @@ struct unaligned_u16 {
 } __attribute__((packed));
 
 /*
- * t, c, data, and datalen may be assumed to be defined for all avp's
+ * t, c, data, and datalen may be assumed to be defined for all AVP's
  */
 
 int message_type_avp (struct tunnel *t, struct call *c, void *data,
@@ -167,7 +167,7 @@ int message_type_avp (struct tunnel *t, struct call *c, void *data,
     if (t->sanity)
     {
         /*
-         * Look ou our state for each message and make sure everything
+         * Look out our state for each message and make sure everything
          * make sense...
          */
         if ((c != t->self) && (c->msgtype < Hello))
@@ -381,8 +381,8 @@ int ignore_avp (struct tunnel *t, struct call *c, void *data, int datalen)
      * The spec says we have to accept authentication information
      * even if we just ignore it, so that's exactly what
      * we're going to do at this point.  Proxy authentication is such
-     * a rediculous security threat anyway except from local
-     * controled machines.
+     * a ridiculous security threat anyway except from local
+     * controlled machines.
      *
      * FIXME: I need to handle proxy authentication as an option.
      * One option is to simply change the options we pass to pppd.
@@ -436,7 +436,7 @@ int result_code_avp (struct tunnel *t, struct call *c, void *data,
                      int datalen)
 {
     /*
-     * Find out what version of l2tp the other side is using.
+     * Find out what version of L2TP the other side is using.
      * I'm not sure what we're supposed to do with this but whatever..
      */
 
@@ -539,7 +539,7 @@ int protocol_version_avp (struct tunnel *t, struct call *c, void *data,
                           int datalen)
 {
     /*
-     * Find out what version of l2tp the other side is using.
+     * Find out what version of L2TP the other side is using.
      * I'm not sure what we're supposed to do with this but whatever..
      */
 
@@ -1478,7 +1478,7 @@ int rx_speed_avp (struct tunnel *t, struct call *c, void *data, int datalen)
 int tx_speed_avp (struct tunnel *t, struct call *c, void *data, int datalen)
 {
     /*
-     * What is the tranmsit baud rate of the call?
+     * What is the transmit baud rate of the call?
      */
     struct unaligned_u16 *raw = data;
 
@@ -1662,7 +1662,7 @@ int handle_avps (struct buffer *buf, struct tunnel *t, struct call *c)
             {
                 if (DEBUG)
                     l2tp_log (LOG_WARNING,
-                         "%s:  don't know how to handle atribute %d.\n",
+                         "%s:  don't know how to handle attribute %d.\n",
                          __FUNCTION__, avp->attr);
                 goto next;
             }
@@ -1710,7 +1710,7 @@ int handle_avps (struct buffer *buf, struct tunnel *t, struct call *c)
             l2tp_log (LOG_DEBUG, "%s: Hidden bit set on AVP.\n", __FUNCTION__);
 #endif
             /* We want to rewrite the AVP as an unhidden AVP
-               and then pass it along as normal.  Remeber how
+               and then pass it along as normal.  Remember how
                long the AVP was in the first place though! */
             hidlen = avp->length;
             if (decrypt_avp (data, t))
@@ -1773,7 +1773,7 @@ int handle_avps (struct buffer *buf, struct tunnel *t, struct call *c)
             else
             {
                 if (DEBUG)
-                    l2tp_log (LOG_WARNING, "%s:  no handler for atribute %d (%s).\n",
+                    l2tp_log (LOG_WARNING, "%s:  no handler for attribute %d (%s).\n",
                          __FUNCTION__, avp->attr,
                          avps[avp->attr].description);
             }

--- a/avpsend.c
+++ b/avpsend.c
@@ -38,7 +38,7 @@ void add_header(struct buffer *buf, _u16 length, _u16 type) {
 }
 
 /* 
- * These routines should add avp's to a buffer
+ * These routines should add AVP's to a buffer
  * to be sent
  */
 

--- a/call.c
+++ b/call.c
@@ -129,7 +129,7 @@ int read_packet (struct call *c)
                 /*
                    * Oops, we were interrupted!
                    * Or, we ran out of data too soon
-                   * anyway, we discared whatever it is we
+                   * anyway, we discarded whatever it is we
                    * have
                  */
                 return 0;
@@ -223,8 +223,8 @@ void call_close (struct call *c)
          * entire tunnel
          */
 
-        /* First deschedule any remaining packet transmissions
-           for this tunnel.  That means Hello's and any reminaing
+        /* First de-schedule any remaining packet transmissions
+           for this tunnel.  That means Hello's and any remaining
            packets scheduled for transmission.  This is a very
            nasty little piece of code here. */
 
@@ -265,7 +265,7 @@ void call_close (struct call *c)
         if (c->closing)
         {
             /* Really close this tunnel, as our
-               StopCCN has been ack'd */
+               StopCCN has been ACK'd */
 #ifdef DEBUG_CLOSE
             l2tp_log (LOG_DEBUG, "%s: Actually closing tunnel %d\n", __FUNCTION__,
                  c->container->ourtid);
@@ -407,9 +407,9 @@ void destroy_call (struct call *c)
 #endif
 
     /*
-     * Kill off pppd and wait for it to
+     * Kill off PPPD and wait for it to
      * return to us.  This should only be called
-     * in rare cases if pppd hasn't already died
+     * in rare cases if PPPD hasn't already died
      * voluntarily
      */
     pid = c->pppd;
@@ -418,8 +418,8 @@ void destroy_call (struct call *c)
       /* Set c->pppd to zero to prevent recursion with child_handler */
       c->pppd = 0;
       /*
-       * There is a bug in some pppd versions where sending a SIGTERM
-       * does not actually seem to kill pppd, and xl2tpd waits indefinately
+       * There is a bug in some PPPD versions where sending a SIGTERM
+       * does not actually seem to kill PPPD, and xl2tpd waits indefinately
        * using waitpid, not accepting any new connections either. Therefor
        * we now use some more force and send it a SIGKILL instead of SIGTERM.
        * One confirmed buggy version of pppd is ppp-2.4.2-6.4.RHEL4

--- a/control.c
+++ b/control.c
@@ -414,7 +414,7 @@ int control_finish (struct tunnel *t, struct call *c)
         /* FIXME: Do we need to be sure they specified a version number?
          *   Theoretically, yes, but we don't have anything in the code
          *   to actually *do* anything with it, so...why check at this point?
-         * We shouldn't be requiring a bearer capabilities avp to be present in
+         * We shouldn't be requiring a bearer capabilities AVP to be present in
          * SCCRQ and SCCRP as they aren't required
          if (t->bc < 0 ) {
          if (DEBUG) l2tp_log(LOG_DEBUG,
@@ -442,7 +442,7 @@ int control_finish (struct tunnel *t, struct call *c)
                 (y != t))
             {
                 /* This can happen if we get a duplicate
-                   StartCCN or if they don't get our ack packet */
+                   StartCCN or if they don't get our ACK packet */
                 /*
                  * But it is legitimate for two different remote systems
                  * to use the same tid
@@ -538,7 +538,7 @@ int control_finish (struct tunnel *t, struct call *c)
         /* FIXME: Do we need to be sure they specified a version number?
          *   Theoretically, yes, but we don't have anything in the code
          *   to actually *do* anything with it, so...why check at this point?
-         * We shouldn't be requiring a bearer capabilities avp to be present in
+         * We shouldn't be requiring a bearer capabilities AVP to be present in
          * SCCRQ and SCCRP as they aren't required
          if (t->bc < 0 ) {
          if (DEBUG) log(LOG_DEBUG,
@@ -746,7 +746,7 @@ int control_finish (struct tunnel *t, struct call *c)
             if (z->cid == p->cid)
             {
                 /* This can happen if we get a duplicate
-                   ICRQ or if they don't get our ack packet */
+                   ICRQ or if they don't get our ACK packet */
                 l2tp_log (LOG_DEBUG,
                      "%s: Peer requested call %d twice, ignoring second one.\n",
                      __FUNCTION__, p->cid);
@@ -1318,7 +1318,7 @@ static inline int check_payload (struct buffer *buf, struct tunnel *t,
     {
         if (DEBUG)
         {
-            l2tp_log (LOG_DEBUG, "%s: Aempted to send payload on tunnel\n",
+            l2tp_log (LOG_DEBUG, "%s: Attempted to send payload on tunnel\n",
                  __FUNCTION__);
         }
         return -EINVAL;
@@ -1329,7 +1329,7 @@ static inline int check_payload (struct buffer *buf, struct tunnel *t,
            no matter what.  we'll look more later */
         if (DEBUG)
         {
-            l2tp_log (LOG_DEBUG, "%s:Recieved to small of packet\n", __FUNCTION__);
+            l2tp_log (LOG_DEBUG, "%s:Received to small of packet\n", __FUNCTION__);
         }
         return -EINVAL;
     }
@@ -1577,7 +1577,7 @@ void send_zlb (void *data)
              __FUNCTION__);
         return;
     }
-    /* Update the counter so we know what Lr was when we last transmited a ZLB */
+    /* Update the counter so we know what Lr was when we last transmitted a ZLB */
     c->prx = c->data_rec_seq_num;
     buf = new_payload (t->peer);
     add_payload_hdr (t, c, buf);
@@ -1665,7 +1665,7 @@ static inline int write_packet (struct buffer *buf, struct tunnel *t, struct cal
 
     /*
      * sync->async conversion if we're doing sync frames
-     * since the pppd driver will expect async frames
+     * since the PPPD driver will expect async frames
      * Write leading flag character
      */
 

--- a/doc/l2tpd.conf.sample
+++ b/doc/l2tpd.conf.sample
@@ -3,7 +3,7 @@
 ;
 ; This example file should give you some idea of how the options for l2tpd
 ; should work.  The best place to look for a list of all options is in
-; the source code itself, until I have the time to write better documetation :)
+; the source code itself, until I have the time to write better documentation :)
 ; Specifically, the file "file.c" contains a list of commands at the end.
 ;
 ; You most definitely don't have to spell out everything as it is done here

--- a/doc/xl2tpd.conf.5
+++ b/doc/xl2tpd.conf.5
@@ -5,8 +5,8 @@ xl2tpd.conf \- L2TPD configuration file
 The xl2tpd.conf file contains configuration information for xl2tpd, the implementation of l2tp protocol.
 
 The configuration file is composed of sections and parameters. Each section
-has a given name which will be used when using the configuration FIFO 
-(normaly /var/run/xl2tpd/l2tp\-control). See xl2tpd.8  for more details.
+has a given name which will be used when using the configuration FIFO
+(normally /var/run/xl2tpd/l2tp\-control). See xl2tpd.8  for more details.
 
 The specific given name 
 .B default
@@ -19,11 +19,11 @@ l2tp tunnels. The default is /etc/xl2tpd/l2tp\-secrets.
 
 .TP 
 .B ipsec saref
-Use IPsec Security Association trackinng. When this is enabled, packets
+Use IPsec Security Association tracking. When this is enabled, packets
 received by xl2tpd should have to extra fields (refme and refhim) which
 allows tracking of multiple clients using the same internal NATed IP
 address, and allows tracking of multiple clients behind the same
-NAT router. This neds to be supported by the kernel. Currently, this
+NAT router. This needs to be supported by the kernel. Currently, this
 only works with Openswan KLIPS in "mast" mode. (see http://www.openswan.org/)
 
 Set this to yes and the system will provide proper SAref values in the
@@ -221,8 +221,8 @@ If set to yes, xl2tpd will automatically dial the LAC during startup.
 .TP 
 .B redial
 If set to yes, xl2tpd will attempt to redial if the call get
-disconected.  Note that, if enabled, xl2tpd will keep passwords in
-memory: a potental security risk.
+disconnected.  Note that, if enabled, xl2tpd will keep passwords in
+memory: a potential security risk.
 
 .TP 
 .B redial timeout

--- a/file.c
+++ b/file.c
@@ -1479,7 +1479,7 @@ int parse_config (FILE * f)
 #ifdef DEBUG_FILE
             l2tp_log (LOG_DEBUG, "parse_config: field is %s, value is %s\n", s, t);
 #endif
-            /* Okay, bit twidling is done.  Let's handle this */
+            /* Okay, bit twiddling is done.  Let's handle this */
             
             switch (parse_one_option (s, t, context | def, data))
             {

--- a/network.c
+++ b/network.c
@@ -612,7 +612,7 @@ void network_thread ()
                 * have already closed or some such nonsense.  To
                 * prevent this from closing the tunnel, if we get a
                 * call on a valid tunnel, but not with a valid CID,
-                * we'll just send a ZLB to ack receiving the packet.
+                * we'll just send a ZLB to ACK receiving the packet.
                 */
                 if (gconfig.debug_tunnel)
                 l2tp_log (LOG_DEBUG,


### PR DESCRIPTION
Fixing minor typo and spelling mistake in xl2tpd.conf.5, l2tpd.conf.sample and code