### PR TITLE
Resurrect openbsd build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ OBJS=xl2tpd.o pty.o misc.o control.o avp.o call.o network.o avpsend.o scheduler.
 SRCS=${OBJS:.o=.c} ${HDRS}
 CONTROL_SRCS=xl2tpd-control.c
 #LIBS= $(OSLIBS) # -lefence # efence for malloc checking
-LDLIBS= -lm
+LDLIBS+= -lm
 EXEC=xl2tpd
 CONTROL_EXEC=xl2tpd-control
 

--- a/network.c
+++ b/network.c
@@ -99,15 +99,6 @@ int init_network (void)
 
 #endif
 
-#ifdef SO_NO_CHECK
-    /* turn off UDP checksums */
-    arg=1;
-    if (setsockopt(server_socket, SOL_SOCKET, SO_NO_CHECK , (void*)&arg,
-                   sizeof(arg)) ==-1) {
-      l2tp_log(LOG_INFO, "unable to turn off UDP checksums");
-    }
-#endif
-
 #ifdef USE_KERNEL
     if (gconfig.forceuserspace)
     {

--- a/osport.h
+++ b/osport.h
@@ -35,4 +35,12 @@
 
 #endif /* defined(SOLARIS) */
 
+#if !defined(LINUX)
+
+/* Declare empty structure to make code portable and keep simple */
+struct in_pktinfo {
+};
+
+#endif
+
 #endif /* _OSPORT_H_ */

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -1595,6 +1595,7 @@ void do_control ()
             }
         }else{
             resf = NULL;
+            res_filename = NULL; /* to avoid 'may be used unitialized' warning */
         }
 
         /* Search for a handler based on request type */

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -30,17 +30,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <time.h>
-#if (__GLIBC__ < 2)
-# if defined(FREEBSD) || defined(OPENBSD)
-#  include <sys/signal.h>
-# elif defined(LINUX)
-#  include <bsd/signal.h>
-# elif defined(SOLARIS) || defined(NETBSD)
-#  include <signal.h>
-# endif
-#else
-# include <signal.h>
-#endif
+#include <signal.h>
 #ifndef LINUX
 # include <sys/socket.h>
 #endif

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -17,7 +17,7 @@
 #define _ISOC99_SOURCE
 #define _XOPEN_SOURCE
 #define _BSD_SOURCE
-#define _XOPEN_SOURCE_EXTENDED
+#define _XOPEN_SOURCE_EXTENDED	1
 #define _GNU_SOURCE
 
 #include <stdlib.h>


### PR DESCRIPTION
Hello,

this change set resurrect building with OpenBSD. Main issue was using Linux-specific IP_PKTINFO option without any protection. Also this series includes several cosmetic changes, which fix annoying compiler warnings.

Changes run tested with OpenBSD-5.9 and compile tested with Linux (glibc-2.22).