### PR TITLE
Fix feature test macro deprecation warnings

### DIFF
--- a/pty.c
+++ b/pty.c
@@ -17,6 +17,7 @@
 #define _ISOC99_SOURCE
 #define _XOPEN_SOURCE
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #define _XOPEN_SOURCE_EXTENDED
 
 #include <stdlib.h>

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -17,6 +17,7 @@
 #define _ISOC99_SOURCE
 #define _XOPEN_SOURCE
 #define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #define _XOPEN_SOURCE_EXTENDED	1
 #define _GNU_SOURCE
 


### PR DESCRIPTION
When compiling xl2tpd under Fedora 24 with gcc (GCC) 6.1.1 20160621 (Red
Hat 6.1.1-3) we get the following warnings

cc -DDEBUG_PPPD -DTRUST_PPPD_TO_DIE -Os -Wall -DSANITY -DLINUX
-I./linux/include/ -DUSE_KERNEL -DIP_ALLOCATION   -c -o xl2tpd.o
xl2tpd.c
In file included from /usr/include/stdlib.h:24:0,
                 from xl2tpd.c:23:
/usr/include/features.h:148:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use # _DEFAULT_SOURCE"
   ^~~~~~~

and

cc -DDEBUG_PPPD -DTRUST_PPPD_TO_DIE -Os -Wall -DSANITY -DLINUX
-I./linux/include/ -DUSE_KERNEL -DIP_ALLOCATION   -c -o pty.o pty.c
In file included from /usr/include/stdlib.h:24:0,
                 from pty.c:22:
/usr/include/features.h:148:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use # _DEFAULT_SOURCE"
   ^~~~~~~

Rather than just replacing _BSD_SOURCE with _DEFAULT_SOURCE lets define
them both as suggested by FEATURE_TEST_MACROS(7)

  _BSD_SOURCE (deprecated since glibc 2.20)
    Defining this macro with any value causes  header  files  to expose
    BSD-derived definitions.

    In glibc versions up to and including 2.18, defining this macro also
    causes BSD definitions to be  preferred  in  some  situations where
    standards   conflict,   unless   one   or   more   of _SVID_SOURCE,
    _POSIX_SOURCE,             _POSIX_C_SOURCE,          _XOPEN_SOURCE,
    _XOPEN_SOURCE_EXTENDED, or _GNU_SOURCE is defined, in which case BSD
    definitions are disfavored.  Since glibc 2.19, _BSD_SOURCE no longer
    causes BSD definitions to be preferred in case of conflicts.

    Since  glibc  2.20,  this  macro is deprecated.  It now has the same
    effect as defining _DEFAULT_SOURCE,  but  generates  a compile-time
    warning    (unless    _DEFAULT_SOURCE   is   also   defined). Use
    _DEFAULT_SOURCE instead.  To allow code that requires _BSD_SOURCE in
    glibc  2.19  and earlier and _DEFAULT_SOURCE in glibc 2.20 and later
    to  compile  without   warnings,   define   both   _BSD_SOURCE and
    _DEFAULT_SOURCE.

Signed-off-by: Andrew Clayton <andrew@digital-domain.net>