### PR TITLE
Remove unnecessary casting of malloc() results

### DIFF
--- a/aaa.c
+++ b/aaa.c
@@ -65,7 +65,7 @@ void reserve_addr (unsigned int addr)
     if (ip_used (addr))
         return;
     tmp = uaddr[addr % ADDR_HASH_SIZE];
-    tmp2 = (struct addr_ent *) malloc (sizeof (struct addr_ent));
+    tmp2 = malloc (sizeof (struct addr_ent));
     uaddr[addr % ADDR_HASH_SIZE] = tmp2;
     tmp2->next = tmp;
     tmp2->addr = addr;

--- a/file.c
+++ b/file.c
@@ -879,7 +879,7 @@ struct iprange *set_range (char *word, char *value, struct iprange *in)
                   "format is '%s <host or ip> - <host or ip>'\n", word);
         return NULL;
     }
-    ipr = (struct iprange *) malloc (sizeof (struct iprange));
+    ipr = malloc (sizeof (struct iprange));
     ipr->next = NULL;
     hp = gethostbyname (value);
     if (!hp)

--- a/misc.c
+++ b/misc.c
@@ -224,7 +224,7 @@ struct ppp_opts *add_opt (struct ppp_opts *option, char *fmt, ...)
 {
     va_list args;
     struct ppp_opts *new, *last;
-    new = (struct ppp_opts *) malloc (sizeof (struct ppp_opts));
+    new = malloc (sizeof (struct ppp_opts));
     if (!new)
     {
         l2tp_log (LOG_WARNING,

--- a/pty.c
+++ b/pty.c
@@ -115,7 +115,7 @@ int getPtyMaster_ptmx(char *ttybuf, int ttybuflen)
 int getPtyMaster_ptm(char *ttybuf, int ttybuflen)
 {
     int amaster, aslave;
-    char *tty = (char*) malloc(64);
+    char *tty = malloc(64);
 
     if((openpty(&amaster, &aslave, tty, NULL, NULL)) == -1)
     {

--- a/scheduler.c
+++ b/scheduler.c
@@ -105,13 +105,12 @@ struct schedule_entry *schedule (struct timeval tv, void (*func) (void *),
     };
     if (q)
     {
-        q->next =
-            (struct schedule_entry *) malloc (sizeof (struct schedule_entry));
+        q->next = malloc (sizeof (struct schedule_entry));
         q = q->next;
     }
     else
     {
-        q = (struct schedule_entry *) malloc (sizeof (struct schedule_entry));
+        q = malloc (sizeof (struct schedule_entry));
         events = q;
     }
     q->tv = tv;

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -437,17 +437,17 @@ int start_pppd (struct call *c, struct ppp_opts *opts)
        stropt[pos++] = strdup ("plugin");
        stropt[pos++] = strdup ("pppol2tp.so");
        stropt[pos++] = strdup ("pppol2tp");
-       stropt[pos] = (char *) malloc (10);
+       stropt[pos] = malloc (10);
        snprintf (stropt[pos], 10, "%d", fd2);
         pos++;
        if (c->container->lns) {
         stropt[pos++] = strdup ("pppol2tp_lns_mode");
         stropt[pos++] = strdup ("pppol2tp_tunnel_id");
-        stropt[pos] = (char *) malloc (10);
+        stropt[pos] = malloc (10);
         snprintf (stropt[pos], 10, "%d", c->container->ourtid);
             pos++;
         stropt[pos++] = strdup ("pppol2tp_session_id");
-        stropt[pos] = (char *) malloc (10);
+        stropt[pos] = malloc (10);
         snprintf (stropt[pos], 10, "%d", c->ourcid);
             pos++;
        }
@@ -920,7 +920,7 @@ struct tunnel *new_tunnel ()
     tmp->txspeed = DEFAULT_TX_BPS;
     memset (tmp->chal_us.reply, 0, MD_SIG_SIZE);
     memset (tmp->chal_them.reply, 0, MD_SIG_SIZE);
-    tmp->chal_them.vector = (unsigned char *) malloc (VECTOR_SIZE);
+    tmp->chal_them.vector = malloc (VECTOR_SIZE);
     return tmp;
 }
 


### PR DESCRIPTION
AIUI in C, code like

    ptr = (char *)malloc(30);

should be written as

    ptr = malloc(30);

as the casting can lead to problems if you forget to include stdlib.h
due to implicitly declared functions having a return type of int. Though
these days GCC will warn loudly about any implicitly declared functions.
See here[0] for a lengthy discussion on the subject, more so the
comments.

There are it seems arguments both for casting as well as not to.
Personally I don't and most C code I read doesn't. In the case of xl2tpd
there are currently 17 calls to malloc and of those, 10 cast the result
and 7 don't.

[0] -
https://www.securecoding.cert.org/confluence/display/c/MEM02-C.+Immediately+cast+the+result+of+a+memory+allocation+function+call+into+a+pointer+to+the+allocated+type?src=contextnavpagetreemode

Signed-off-by: Andrew Clayton <andrew@digital-domain.net>