### PR TITLE
Use left shift rather than pow() function.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,6 @@ OBJS=xl2tpd.o pty.o misc.o control.o avp.o call.o network.o avpsend.o scheduler.
 SRCS=${OBJS:.o=.c} ${HDRS}
 CONTROL_SRCS=xl2tpd-control.c
 #LIBS= $(OSLIBS) # -lefence # efence for malloc checking
-LDLIBS+= -lm
 EXEC=xl2tpd
 CONTROL_EXEC=xl2tpd-control
 

--- a/network.c
+++ b/network.c
@@ -30,8 +30,6 @@
 #include "ipsecmast.h"
 #include "misc.h"    /* for IPADDY macro */
 
-#include <math.h>
-
 char hostname[256];
 struct sockaddr_in server, from;        /* Server and transmitter structs */
 int server_socket;              /* Server socket */
@@ -261,7 +259,7 @@ void control_xmit (void *b)
         /*
            * Adaptive timeout with exponential backoff
          */
-        tv.tv_sec = 1*pow(2, buf->retries-1);
+        tv.tv_sec = 1LL << (buf->retries-1);
         tv.tv_usec = 0;
         schedule (tv, control_xmit, buf);
 #ifdef DEBUG_CONTROL_XMIT


### PR DESCRIPTION
This removes a dependency to libm. On constrained systems
such as OpenWRT, this will add too much bloat to the binary.

This partially undoes commit 64f8ad1ab68b4b12f848b2d995a8f5da2bf0c4f0
and commit 23e47d52915c70515b8aa828e2ec3b2272a280d7