### PR TITLE
xl2tpd-control: Fix control file write size

### DIFF
--- a/xl2tpd-control.c
+++ b/xl2tpd-control.c
@@ -309,7 +309,8 @@ int main (int argc, char *argv[])
     }
     
     /* pass command to control pipe */
-    if (write (control_fd, buf, ftell (mesf)) < 0)
+    ssize_t size = strlen(buf) + 1;
+    if (write (control_fd, buf, size) != size)
     {
       int errorno = errno;
       print_error (ERROR_LEVEL,


### PR DESCRIPTION
ftell(mesf) returns 0 on my setup (uname -a "Linux OpenWrt 4.1.38 #1 SMP PREEMPT Fri Nov 17 14:34:13 UTC 2017 armv7l GNU/Linux").

Signed-off-by: Alin Nastac <alin.nastac@gmail.com>