### PR TITLE
Fix for ENODEV (No such device) error with Linux kernel 4.15

### DIFF
--- a/file.c
+++ b/file.c
@@ -42,6 +42,8 @@ int init_config ()
 
     gconfig.port = UDP_LISTEN_PORT;
     gconfig.sarefnum = IP_IPSEC_REFINFO; /* default use the latest we know */
+    gconfig.ipsecsaref = 0; /* default off - requires patched KLIPS kernel module */
+    gconfig.forceuserspace = 0; /* default off - allow kernel decap of data packets */
     gconfig.listenaddr = htonl(INADDR_ANY); /* Default is to bind (listen) to all interfaces */
     gconfig.debug_avp = 0;
     gconfig.debug_network = 0;

--- a/network.c
+++ b/network.c
@@ -78,23 +78,27 @@ int init_network (void)
      * For L2TP/IPsec with KLIPSng, set the socket to receive IPsec REFINFO
      * values.
      */
-    arg=1;
-    if(setsockopt(server_socket, IPPROTO_IP, gconfig.sarefnum,
-		  &arg, sizeof(arg)) != 0) {
-	    l2tp_log(LOG_CRIT, "setsockopt recvref[%d]: %s\n", gconfig.sarefnum, strerror(errno));
-
-	    gconfig.ipsecsaref=0;
+    if (!gconfig.ipsecsaref)
+    {
+        l2tp_log (LOG_INFO, "Not looking for kernel SAref support.\n");
     }
-
-    arg=1;
-    if(setsockopt(server_socket, IPPROTO_IP, IP_PKTINFO, (char*)&arg, sizeof(arg)) != 0) {
-	    l2tp_log(LOG_CRIT, "setsockopt IP_PKTINFO: %s\n", strerror(errno));
+    else
+    {
+        arg=1;
+        if(setsockopt(server_socket, IPPROTO_IP, gconfig.sarefnum,  &arg, sizeof(arg)) != 0) {
+            l2tp_log(LOG_CRIT, "setsockopt recvref[%d]: %s\n", gconfig.sarefnum, strerror(errno));
+            gconfig.ipsecsaref=0;
+        }
+        else
+        {
+            arg=1;
+            if(setsockopt(server_socket, IPPROTO_IP, IP_PKTINFO, (char*)&arg, sizeof(arg)) != 0) {
+                l2tp_log(LOG_CRIT, "setsockopt IP_PKTINFO: %s\n", strerror(errno));
+            }
+        }
     }
 #else
-    {
-	l2tp_log(LOG_INFO, "No attempt being made to use IPsec SAref's since we're not on a Linux machine.\n");
-    }
-
+    l2tp_log(LOG_INFO, "No attempt being made to use IPsec SAref's since we're not on a Linux machine.\n");
 #endif
 
 #ifdef USE_KERNEL


### PR DESCRIPTION
See issue https://github.com/xelerance/xl2tpd/issues/147

With kernel 4.15, in the ancillary IP_PKTINFO data received during a recvmsg()
call, `ipi_ifindex` is a bogus value that results in an ENODEV error in the
subsequent sendmsg() call.

This fix no longer attempts to obtain the ancillary IP_PKTINFO data, except if
ipsecsaref is set to yes, e.g. when wanting to use a KLIPS patched kernel.

gconfig.ipsecsaref and gconfig.forceuserspace were implicitly set to zero, now
are explicitly set to zero in file.c for clarity.