### PR TITLE
osport.h: replace SUSv3-specific functions by POSIX variants

### DIFF
--- a/osport.h
+++ b/osport.h
@@ -43,4 +43,11 @@ struct in_pktinfo {
 
 #endif
 
+#if defined __UCLIBC__ && !defined UCLIBC_SUSV3_LEGACY_MACROS
+# define index(x, y)        strchr(x, y)
+# define bcopy(S1, S2, LEN) ((void)memmove(S2, S1, LEN))
+# define bzero(S1, LEN)     ((void)memset(S1,  0, LEN))
+# define bcmp(S1,S2,LEN)    ((memcmp(S2, S1, LEN)==0)?0:1)
+#endif /* defined __UCLIBC__ && !defined UCLIBC_SUSV3_LEGACY_MACROS */
+
 #endif /* _OSPORT_H_ */


### PR DESCRIPTION
Replace SUSV3-specific functions index, bcopy, bzero and bcmp by their
POSIX variants.

[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/xl2tp/0001-legacy.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>