### PR TITLE
sockopt bug fix for multiple IP's

### DIFF
--- a/network.c
+++ b/network.c
@@ -86,7 +86,7 @@ int init_network (void)
     else
     {
         arg=1;
-        if(setsockopt(server_socket, IPPROTO_IP, gconfig.sarefnum,  &arg, sizeof(arg)) != 0) {
+        if(setsockopt(server_socket, IPPROTO_IP, gconfig.sarefnum,  &arg, sizeof(arg)) != 0 && !gconfig.forceuserspace) {
             l2tp_log(LOG_CRIT, "setsockopt recvref[%d]: %s\n", gconfig.sarefnum, strerror(errno));
             gconfig.ipsecsaref=0;
         }


### PR DESCRIPTION
Allow the use of IPsec SAref if force userspace is enabled in xl2tpd.conf.

There's a bug with xl2tpd where if it's unable to set the socket option for IPsec SAREF processing in the kernel, it'll never reach the "else" condition to set the sock opt for userspace ipsec saref.

This only appears to affect setups where "listen-addr" is set to 0.0.0.0 (all IP's)

So to remedy this, check if "force userspace" is enabled in xl2tpd.conf, If it is, don't bother checking for kernel support for saref, continue on and set the sockopt for userspace saref.

Here is the setup that was used to replicate this problem:
- StrongSwan/xl2tpd v1.3.12+ (problem was introduced on this [commit](https://github.com/xelerance/xl2tpd/commit/cc909bbb20d3e6e216c3d11e0f328ff906f289a8))
- CentOS 7.6 (although I suspect this will affect other platforms)
- Kernel 4.9.x and kernel 5.1.x mainline both tested and working with this patch
- Use "listen-addr = 0.0.0.0" in xl2tpd.conf
- Windows 10 x64 client, L2TP/IPsec.

Connecting to any IP other than the primary IP of the server fails with this message:

> control_finish: Peer requested tunnel 37 twice, ignoring second one.

So for example, if you had xl2tpd/strongswan listen on these IP's, connecting using the secondary/tertiary addresses would fail with the above message printed in the syslog.
10.10.10.1 (primary)
10.10.10.2 (secondary)
10.10.10.3 (tertiary)

I've tested my patch against the latest master and it works fine. If there is some better way to fix this bug or if there's more information needed, please let me know.

Please note: my patch requires adding "force userspace = yes" to xl2tpd.conf after applying to fix the bug described.