### PR TITLE
set_flow: result of operation is garbage or undefined

### DIFF
--- a/file.c
+++ b/file.c
@@ -463,7 +463,7 @@ int set_autodial (char *word, char *value, int context, void *item)
 
 int set_flow (char *word, char *value, int context, void *item)
 {
-    int v;
+    int v = -1;
     set_boolean (word, value, &v);
     if (v < 0)
         return -1;


### PR DESCRIPTION
There is no check for the return value of set_boolen() call, so 'v' could be still undefined if set_boolen() returns -1.
This patch defines 'v' to -1, what in this case will mean immediately return from set_flow.