### PR TITLE
Update man pages, fix typo

### DIFF
--- a/doc/xl2tpd-control.8
+++ b/doc/xl2tpd-control.8
@@ -1,32 +1,48 @@
-.TH "xl2tpd-control" "8" "" "Alexander Dorokhov" ""
-.SH "NAME"
-xl2tpd\-control \- Layer 2 Tunnelling Protocol Daemon Contorl Utility
-.SH "DESCRIPTION"
-A Layer 2 Tunneling Protocol Daemon Control Utility for Linux.
+.TH xl2tpd-control 8  "Sep 2020"
 
-Currently maintained by Xelerance
-  http://www.xelerance.com/software/xl2tpd/
+.SH NAME
+xl2tpd\-control \- Layer 2 Tunnelling Protocol Daemon Control Utility.
 
-.SH "SYNOPSIS"
-.HP \w'\fBipsec\fR\ 'u
-\fBxl2tpd-control\fR [\fI-c\fR <PATH>] \fI<command>\fR \fI<tunnel name>\fR [\fI<COMMAND OPTIONS>\fR]
+.SH DESCRIPTION
+xl2tpd is an implementation of the Layer 2 Tunnelling Protocol (RFC 2661).
+L2TP allows to tunnel PPP over UDP. Some ISPs use L2TP to tunnel user sessions
+from dial-in servers (modem banks, ADSL DSLAMs) to back-end PPP servers.
+Another important application is Virtual Private Networks where the IPsec
+protocol is used to secure the L2TP connection (L2TP/IPsec, RFC 3193).
+
+xl2tpd works by opening a pseudo-tty for communicating with pppd.
+It runs completely in userspace but supports kernel mode L2TP.
+
+xl2tpd supports IPsec SA Reference tracking to enable overlapping internak
+NAT'ed IP's by different clients (eg all clients connecting from their
+linksys internal IP 192.168.1.101) as well as multiple clients behind
+the same NAT router.
+
+On Linux xl2tpd supports the pppol2tp kernel mode operations by using
+kernel 2.6.23 or higher, or via a patch in contrib for 2.4.x kernels.
+Note that kernel mode and IPsec SA Reference tracking do not yet work
+together.
+
+.SH SYNOPSIS
+.HP
+\fBxl2tpd-control\fR [\fI-c\fR <PATH>] \fI<command>\fR \fI<tunnel_name>\fR [\fI<COMMAND OPTIONS>\fR]
 
 
-.SH "OPTIONS"
+.SH OPTIONS
 .TP
 .B -c
-This option specifies xl2tpd control file
+This option specifies xl2tpd control file.
 
 .TP
 .B -d
-This option specify xl2tpd-control to run in debug mode
+This option enables debugging mode.
 
-.SH "COMMANDS"
+.SH COMMANDS
 .TP
 .B add
 Adds new or modify existing lac configuration. Configuration must be
 specified as command options in <key>=<value> pairs format. See available
-options in xl2tpd.conf(5)
+options in xl2tpd.conf(5).
 
 .TP
 .B connect
@@ -69,22 +85,27 @@ Adds new or modify existing lns configuration.
 .TP
 .B available
 
-.SH "BUGS"
+.SH BUGS
+Please send bugs and comments to xl2tpd@lists.xelerance.com
+or use the github project page https://github.com/xelerance/xl2tpd.
 
-Please address bugs and comment to xl2tpd@lists.xelerance.com
-.SH "SEE ALSO"
+.SH SEE ALSO
+xl2tpd.conf(5),
+xl2tpd(8),
+pppd(8)
 
-\fB\fRxl2tpd.conf(5)
-.SH "AUTHORS"
-Forked from l2tpd by Xelerance (http://www.xelerance.com/software/xl2tpd/
+.SH AUTHORS
+Forked from l2tpd by Xelerance: https://github.com/xelerance/xl2tpd
 
 Michael Richardson <mcr@xelerance.com>
+.br
 Paul Wouters <paul@xelerance.com>
+.br
 Samir Hussain <shussain@xelerance.com>
 
 Many thanks to Jacco de Leeuw <jacco2@dds.nl> for maintaining l2tpd.
 
-Patched contributed by:
+Patches contributed by:
 Alexander Dorokhov <alex.dorokhov@gmail.com>
 
 Previous development was hosted at sourceforge

--- a/doc/xl2tpd.8
+++ b/doc/xl2tpd.8
@@ -1,23 +1,36 @@
-.TH "xl2tpd" "8" "" "Jeff McAdams" ""
-.SH "NAME"
-xl2tpd \- Layer 2 Tunnelling Protocol Daemon
-.SH "DESCRIPTION"
-A Layer 2 Tunneling Protocol VPN client/daemon for Linux and other POSIX-based
-OSs. Based off of L2TPd 0.61 from 
-  http://www.marko.net/l2tp 
+.TH xl2tpd 8 "Sep 2020"
+
+.SH NAME
+xl2tpd \- Layer 2 Tunnelling Protocol Daemon.
+
+.SH DESCRIPTION
+xl2tpd is an implementation of the Layer 2 Tunnelling Protocol (RFC 2661).
+L2TP allows to tunnel PPP over UDP. Some ISPs use L2TP to tunnel user sessions
+from dial-in servers (modem banks, ADSL DSLAMs) to back-end PPP servers.
+Another important application is Virtual Private Networks (VPN) where the
+IPsec protocol is used to secure the L2TP connection (L2TP/IPsec, RFC 3193).
+
+xl2tpd works by opening a pseudo-tty for communicating with pppd.
+It runs completely in userspace but supports kernel mode L2TP.
+
+xl2tpd supports IPsec SA Reference tracking to enable overlapping internak
+NAT'ed IP's by different clients (eg all clients connecting from their
+linksys internal IP 192.168.1.101) as well as multiple clients behind
+the same NAT router.
+
+On Linux xl2tpd supports the pppol2tp kernel mode operations by using
+kernel 2.6.23 or higher, or via a patch in contrib for 2.4.x kernels.
+Note that kernel mode and IPsec SA Reference tracking do not yet work
+together.
+
+This implementation is based on L2TPd 0.61 from http://www.marko.net/l2tp
 and patches collected by Jacco de Leeuw at
-  http://www.jacco2.dds.nl/networking/openswan-l2tp.html
+http://www.jacco2.dds.nl/networking/openswan-l2tp.html.
 
-Currently maintained by Xelerance
-  http://www.xelerance.com/software/xl2tpd/
-
-xl2tpd implements the Layer 2 Tunnelling Protocol, defined by RFC 2661.
-
-.SH "OPTIONS"
+.SH OPTIONS
 .TP 
 .B -D
-This option prevents xl2tpd from detaching from the terminal and
-daemonizing.  
+This option prevents xl2tpd from detaching from the terminal and daemonizing.
 
 .TP 
 .B -l
@@ -25,45 +38,51 @@ This option tells xl2tpd to use syslog for logging even when \fB\-D\fR
 was specified.
 
 .TP
-.B -c <config file>
-Tells xl2tpd to use an alternate config file.  Default is
-/etc/xl2tpd/xl2tpd.conf. Fallback configuration file is
-/etc/l2tpd/l2tpd.conf
+.B -c <config_file>
+Set an alternate config file.
+Fallback configuration file is /etc/l2tpd/l2tpd.conf.
 
 .TP 
-.B -s <secret file>
-Tells xl2tpd to use an alternate "secrets" file.  Default is
-/etc/xl2tpd/l2tp-secrets
+.B -s <secret_file>
+Tells xl2tpd to use an alternate "secrets" file.
 
 .TP 
-.B -p <pid file>
-Tells xl2tpd to use an alternate pid file.  Default is
-/var/run/xl2tpd/xl2tpd.pid
+.B -p <pid_file>
+Set an alternate pid file.
+Default is /var/run/xl2tpd/xl2tpd.pid.
 
 .TP 
-.B -C <control file>
-Tells xl2tpd to use an alternate control file.  Default is
-/var/run/xl2tpd/l2tp-control
+.B -C <control_file>
+Set an alternate control file.
 
 
-.SH "FILES"
+.SH FILES
+.IP /etc/xl2tpd/xl2tpd.conf
+Configuration file of xl2tpd, used by default.
 
-\fB\fR/etc/xl2tpd/xl2tpd.conf \fB\fR/etc/xl2tpd/l2tp\-secrets 
-\fB\fR/var/run/xl2tpd/l2tp\-control
-.SH "BUGS"
+.IP /etc/xl2tpd/l2tp-secrets
+Secrets file, used by default.
 
-Please address bugs and comment to xl2tpd@lists.xelerance.com
-.SH "SEE ALSO"
+.IP /var/run/xl2tpd/l2tp\-control
+Control file, used by default.
 
-\fB\fRxl2tpd.conf(5)
-.SH "AUTHORS"
-Forked from l2tpd by Xelerance (http://www.xelerance.com/software/xl2tpd/
+.SH BUGS
+Please send bugs and comments to xl2tpd@lists.xelerance.com
+or use the github project page https://github.com/xelerance/xl2tpd.
+
+.SH SEE ALSO
+xl2tpd.conf(5),
+xl2tpd-control(8),
+pppd(8)
+
+.SH AUTHORS
+Forked from l2tpd by Xelerance: https://github.com/xelerance/xl2tpd
 
 Michael Richardson <mcr@xelerance.com>
+.br
 Paul Wouters <paul@xelerance.com>
 
 Many thanks to Jacco de Leeuw <jacco2@dds.nl> for maintaining l2tpd.
-
 
 Previous development was hosted at sourceforge
 (http://www.sourceforge.net/projects/l2tpd) by:
@@ -73,7 +92,6 @@ Scott Balmos <sbalmos@iglou.com>
 David Stipp <dstipp@one.net>
 .br
 Jeff McAdams <jeffm@iglou.com>
-
 
 Based off of l2tpd version 0.60
 .br

--- a/file.c
+++ b/file.c
@@ -463,7 +463,7 @@ int set_autodial (char *word, char *value, int context, void *item)
 
 int set_flow (char *word, char *value, int context, void *item)
 {
-    int v;
+    int v = -1;
     set_boolean (word, value, &v);
     if (v < 0)
         return -1;


### PR DESCRIPTION
Yet another pull request that _improves_ man pages for **xl2tpd(8)** and **xl2tpd-control(8)** and fix some typo(s).