### PR TITLE
Update README: typo, links to RFC, link to travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,24 @@
 # xl2tpd
 
-xl2tpd is an implementation of the Layer 2 Tunnelling Protocol (RFC 2661).
+[![Build Status](https://travis-ci.org/xelerance/xl2tpd.svg?branch=1.3.16dev)](https://travis-ci.org/xelerance/xl2tpd)
+
+xl2tpd is a **FREE** implementation of the Layer 2 Tunneling Protocol
+as defined by [RFC 2661](https://tools.ietf.org/rfc/rfc2661.txt).
 L2TP allows you to tunnel PPP over UDP. Some ISPs use L2TP to tunnel user
 sessions from dial-in servers (modem banks, ADSL DSLAMs) to back-end PPP
 servers. Another important application is Virtual Private Networks where
-the IPsec protocol is used to secure the L2TP connection (L2TP/IPsec,
-RFC 3193). The L2TP/IPsec protocol is mainly used by Windows and
-Mac OS X clients. On Linux, xl2tpd can be used in combination with IPsec
-implementations such as Openswan.
-Example configuration files for such a setup are included in this RPM.
+the IPsec protocol is used to secure the L2TP connection (L2TP/IPsec is
+defined by [RFC 3193](https://tools.ietf.org/rfc/rfc3193.txt).
 
-xl2tpd works by opening a pseudo-tty for communicating with pppd.
-It runs completely in userspace but supports kernel mode L2TP.
+xl2tpd uses a pseudo-tty to communicate with pppd.
+It runs in userspace but supports kernel mode L2TP.
 
-xl2tpd supports IPsec SA Reference tracking to enable overlapping internak
+xl2tpd supports IPsec SA Reference tracking to enable overlapping internal
 NAT'ed IP's by different clients (eg all clients connecting from their
 linksys internal IP 192.168.1.101) as well as multiple clients behind
 the same NAT router.
 
-xl2tpd supports the pppol2tp kernel mode operations on 2.6.23 or higher,
-or via a patch in contrib for 2.4.x kernels. Note that kernel mode and
-IPsec SA Reference tracking do not yet work together.
-
-Xl2tpd is based on the 0.69 L2TP by Jeff McAdams <jeffm@iglou.com>
+Xl2tpd is based on the L2TP code base of Jeff McAdams <jeffm@iglou.com>.
 It was de-facto maintained by Jacco de Leeuw <jacco2@dds.nl> in 2002 and 2003.
 
 NOTE: In Linux kernel 4.15+ there is a kernel bug with ancillary IP_PKTINFO.
@@ -33,11 +29,16 @@ NOTE: In Linux kernel 4.15+ there is a kernel bug with ancillary IP_PKTINFO.
     make
     sudo make install
 
+The xl2tpd.conf(5) man page has details on how to configure xl2tpd.
+
+
 ## Mailing Lists
 
-https://lists.openswan.org/cgi-bin/mailman/listinfo/xl2tpd is home of the mailing list.
+https://lists.openswan.org/cgi-bin/mailman/listinfo/xl2tpd
+is home of the mailing list.
 
-Note: This is a closed list - you **must** be subscribed to post.
+Note: This is a closed list - you **must** be subscribed to be able
+to post mails.
 
 ## Security Vulnerability
 


### PR DESCRIPTION
* Typo ( tunnelling=> tunneling, internak => internal)
* Adding links to RFC 2661 and 3193 (txt format)
* Adding link to travis CI
* Remove info about 1) 2.6.x Linux Kernels, 2) about RPM and 3) that it used mainly by Windows and MacOSX clients.

Ok?
