### PR TITLE
xl2tpd-control: fix segfaults

### DIFF
--- a/xl2tpd-control.c
+++ b/xl2tpd-control.c
@@ -83,7 +83,8 @@ struct command_t commands[] = {
     {"available",     &command_available,     TUNNEL_NOT_REQUIRED},
     {"add-lns",       &command_add_lns,       TUNNEL_REQUIRED},
     {"status-lns",    &command_status_lns,    TUNNEL_REQUIRED},
-    {"remove-lns",    &command_remove_lns,    TUNNEL_REQUIRED}
+    {"remove-lns",    &command_remove_lns,    TUNNEL_REQUIRED},
+    {},
 };
 
 void usage()

--- a/xl2tpd-control.c
+++ b/xl2tpd-control.c
@@ -96,7 +96,7 @@ void usage()
             "   --help  show this help message\n\n"
             "List of supported commands:\n"
             "add-lac, status-lac, remove-lac, connect-lac, disconnect-lac\n"
-            "add-lns, status-lns, remove-lns, avaliable\n\n"
+            "add-lns, status-lns, remove-lns, available\n\n"
             "See xl2tpd-control(8) man page for more details.\n");
 }
 


### PR DESCRIPTION
The refactoring in 1.3.16 introduces some easy segfaults in addition to user space incompatibilities (https://github.com/openwrt/packages/pull/13866)