### PR TITLE
debian: Add systemd .service

### DIFF
--- a/debian/xl2tpd.service
+++ b/debian/xl2tpd.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Level 2 Tunnel Protocol Daemon (L2TP)
+After=network.target
+After=ipsec.service
+Wants=ipsec.service
+
+[Service]
+Type=simple
+Environment=XL2TPD_RUN_DIR=/var/run/xl2tpd
+EnvironmentFile=-/etc/default/xl2tpd
+# Not using RuntimeDirectory since this directory may be modified in /etc/default/xl2tpd
+ExecStartPre=-mkdir -p $XL2TPD_RUN_DIR
+ExecStart=/usr/sbin/xl2tpd -D $DAEMON_OPTS
+PIDFile=/run/xl2tpd/xl2tpd.pid
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This is intended to be functionally equivalent to the existing init
script at debian/xl2tpd.init, and in particular to respect any changes
made to /etc/default/xl2tpd on existing installations. As a result,
rather than using RuntimeDirectory=xl2tpd to create /var/run/xl2tpd, it
is created explicitly with an ExecStartPre command.

Fixes #50 (and #51: no tmpfiles snippet is needed since the directory is
created when the unit is activated).

Without this change, a unit is generated by [systemd-sysv-generator](https://www.freedesktop.org/software/systemd/man/systemd-sysv-generator.html) which simply invokes the init script. `systemd-sysv-generator` respects the init script's LSB header and enables the unit by default; and this cannot be controlled by the [systemd-preset](https://www.freedesktop.org/software/systemd/man/systemd.preset.html) mechanism, which allows the distributor to disable certain units which would otherwise be enabled. We wish to disable xl2tpd by default on Endless OS – it is installed for those users who need to use it, via the l2tp NetworkManager plugin, which does not need the system service.