### PR TITLE
Update control.c -- when checking for errors after write(2), converting to ssize_t is better than to size_t

### DIFF
--- a/control.c
+++ b/control.c
@@ -1640,7 +1640,7 @@ static inline int write_packet (struct buffer *buf, struct tunnel *t, struct cal
                  __FUNCTION__);
             return -EINVAL;
         }
-        else if ((size_t)err < 0)
+        else if ((ssize_t)err < 0)
         {
             if ((errno == EAGAIN) || (errno == EINTR))
             {


### PR DESCRIPTION
Converting a negative `int` to `size_t` will be positive. If conversion is necessary at all, `ssize_t` is better.