### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+xl2tpd (1.3.17-2) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster (oldstable):
+    + xl2tpd: Drop versioned constraint on lsb-base in Depends.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 25 Oct 2022 17:01:34 -0000
+
 xl2tpd (1.3.17-1) unstable; urgency=medium
 
   [ Samir Hussain ]

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Package: xl2tpd
 Architecture: any
 Multi-Arch: foreign
 Provides: l2tpd
-Depends: ${shlibs:Depends}, ${misc:Depends}, ppp, lsb-base (>= 3.0-6)
+Depends: ${shlibs:Depends}, ${misc:Depends}, ppp, lsb-base
 Description: layer 2 tunneling protocol implementation
  xl2tpd is an open source implementation of the L2TP tunneling
  protocol (RFC2661).  xl2tpd is forked from l2tpd and is maintained by


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/xl2tpd/20b9e651-ec3a-489b-afa5-161c93b26a68.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package xl2tpd: lines which differ (wdiff format)
* Depends: libc6 (>= 2.34), libpcap0.8 (>= 0.9.8), ppp, lsb-base [-(>= 3.0-6)-]

No differences were encountered between the control files of package \*\*xl2tpd-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/20b9e651-ec3a-489b-afa5-161c93b26a68/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/20b9e651-ec3a-489b-afa5-161c93b26a68/diffoscope)).
