### PR TITLE
control: avoid compiler warnings.

### DIFF
--- a/control.c
+++ b/control.c
@@ -250,9 +250,9 @@ int control_finish (struct tunnel *t, struct call *c)
             add_bearer_caps_avp (buf, t->ourbc);
             /* FIXME:  Tie breaker */
             add_firmware_avp (buf);
-            if (t->lac && t->lac->hostname && t->lac->hostname[0])
+            if (t->lac && t->lac->hostname[0])
                 add_hostname_avp (buf, t->lac->hostname);
-            else if (t->lns && t->lns->hostname && t->lns->hostname[0])
+            else if (t->lns && t->lns->hostname[0])
                 add_hostname_avp (buf, t->lns->hostname);
             else
                 add_hostname_avp (buf, hostname);
@@ -468,9 +468,9 @@ int control_finish (struct tunnel *t, struct call *c)
         add_frame_caps_avp (buf, t->ourfc);
         add_bearer_caps_avp (buf, t->ourbc);
         add_firmware_avp (buf);
-        if (t->lac && t->lac->hostname && t->lac->hostname[0])
+        if (t->lac && t->lac->hostname[0])
             add_hostname_avp (buf, t->lac->hostname);
-        else if (t->lns && t->lns->hostname && t->lns->hostname[0])
+        else if (t->lns && t->lns->hostname[0])
             add_hostname_avp (buf, t->lns->hostname);
         else
             add_hostname_avp (buf, hostname);


### PR DESCRIPTION
gcc warns about hostname always being non-NULL, this is correct since it's a fixed buffer inside the lac and lns structures, thus if the pointer to the structure is non-NULL, so will ->hostname on that, so we just need to test ->hostname[0].

Reference warning being "fixed":

control.c: In function ‘control_finish’:
control.c:253:24: warning: the comparison will always evaluate as ‘true’ for the address of ‘hostname’ will never be NULL [-Waddress]
  253 |             if (t->lac && t->lac->hostname && t->lac->hostname[0])
      |                        ^~
In file included from l2tp.h:34,
                 from control.c:23:
file.h:122:10: note: ‘hostname’ declared here
  122 |     char hostname[STRLEN];      /* Hostname to report */
      |          ^~~~~~~~