### PR TITLE
xl2tpd: Close calls when underlying pppd terminate.

### DIFF
--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -257,6 +257,9 @@ static void child_handler (int sig)
             {
                 if (c->pppd == pid)
                 {
+                    /* pid is no longer valid, avoid killing it later by accident in destroy_call() */
+                    c->pppd = 0;
+
                     if ( WIFEXITED( status ) )
                     {
                         l2tp_log (LOG_DEBUG, "%s : pppd exited for call %d with code %d\n", __FUNCTION__,
@@ -283,6 +286,8 @@ static void child_handler (int sig)
 #endif
                     close (c->fd);
 #ifdef USE_KERNEL
+                 } else {
+                     call_close (c);
                  }
 #endif
                     c->fd = -1;


### PR DESCRIPTION
Unsure the cause, but we found that upon ppp terminating xl2tpd would only reap the PID, but not actually close the inner call, then at a later stage would issue a kill() for that PID.

In our environment with high call turnover this would eventually result in xl2tpd kill()'ing other critical services like mariadb and/or syslog-ng which would upon reloads and rotations have a tendency to re-use PIDs that were previously used by pppd processes.

We also believe that this should sort out the problem where IPs wouldn't get cycled and re-used.

Closes: #252
Closes: #255