### PR TITLE
Only force userspace when ipsec saref enabled

### DIFF
--- a/file.c
+++ b/file.c
@@ -1231,7 +1231,7 @@ int set_ipsec_saref (char *word, char *value, int context, void *item)
 	    if(g->ipsecsaref) {
 		    l2tp_log(LOG_INFO, "Enabling IPsec SAref processing for L2TP transport mode SAs\n");
 	    }
-	    if(g->forceuserspace != 1) {
+	    if(g->ipsecsaref && g->forceuserspace != 1) {
 		    l2tp_log(LOG_WARNING, "IPsec SAref does not work with L2TP kernel mode yet, enabling force userspace=yes\n");
 		    g->forceuserspace = 1;
 	    }


### PR DESCRIPTION
forceuserspace currently gets set even if 'ipsec saref = no', but disabling ipsec saref shouldn't automatically force userspace mode since kernel mode may be desired.