### PR TITLE
debian: Install xl2tpd.service

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -59,6 +59,7 @@ binary-arch: build install
 	dh_installexamples
 #	dh_install
 	dh_installinit
+	dh_installsystemd
 	dh_installman
 	cp debian/lintian-overrides \
 		debian/xl2tpd/usr/share/lintian/overrides/xl2tpd


### PR DESCRIPTION
9ef5b21de2c0ec6b76cfaa4d42475307f2a8b9fe added debian/xl2tpd.service. But since dh_installsystemd was not run during package build, the file was not actually included in the package.

Add that step.

(As far as I can tell, I did not notice this when submitting #226 because I was testing the change against an older branch of xl2tpd, which predated d666b43b331637c7f18a6550226229d6bda1d02d and so was on an older debhelper compat level (10). According to https://www.man7.org/linux/man-pages/man7/debhelper-compat-upgrade-checklist.7.html, compat level 12 removed handling of systemd units from `dh_installinit`. )