### PR TITLE
Fix build with GCC 15

### DIFF
--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -74,7 +74,7 @@ static int control_handle_lac_hangup(FILE* resf, char* bufp);
 static int control_handle_lac_disconnect(FILE* resf, char* bufp);
 static int control_handle_lac_add_modify(FILE* resf, char* bufp);
 static int control_handle_lac_remove(FILE* resf, char* bufp);
-static int control_handle_lac_status();
+static int control_handle_lac_status(FILE*, char*);
 static int control_handle_lns_remove(FILE* resf, char* bufp);
 
 static struct control_requests_handler control_handlers[] = {
@@ -1549,7 +1549,7 @@ static int control_handle_lac_remove(FILE* resf, char* bufp){
     return 1;
 }
 
-static int control_handle_lac_status(){
+static int control_handle_lac_status(FILE*, char*){
     show_status ();
     return 1;
 }


### PR DESCRIPTION
GCC 15 defaults to C23, in which the interpretation of function declarations without parameters changed from unspecified to `void`.  This results in `control_handle_lac_status` not being compatible with the expected callback function type.  Adding the expected type parameters, albeit unused, fixes the compatibility.