### PR TITLE
Fix build with GCC 15

### DIFF
--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -74,7 +74,7 @@ static int control_handle_lac_hangup(FILE* resf, char* bufp);
 static int control_handle_lac_disconnect(FILE* resf, char* bufp);
 static int control_handle_lac_add_modify(FILE* resf, char* bufp);
 static int control_handle_lac_remove(FILE* resf, char* bufp);
-static int control_handle_lac_status();
+static int control_handle_lac_status(FILE* resf, char* bufp);
 static int control_handle_lns_remove(FILE* resf, char* bufp);
 
 static struct control_requests_handler control_handlers[] = {
@@ -1549,7 +1549,7 @@ static int control_handle_lac_remove(FILE* resf, char* bufp){
     return 1;
 }
 
-static int control_handle_lac_status(){
+static int control_handle_lac_status(FILE*, char*){
     show_status ();
     return 1;
 }


### PR DESCRIPTION
GCC 15 (which defaults to C23) prints:

```
cc -DDEBUG_PPPD -DTRUST_PPPD_TO_DIE -Os -Wall -Wextra -DSANITY -DLINUX -I./linux/include/ -DUSE_KERNEL -DIP_ALLOCATION   -c -o xl2tpd.o xl2tpd.c
xl2tpd.c:91:35: error: initialization of 'int (*)(FILE *, char *)' from incompatible pointer type 'int (*)(void)' [-Wincompatible-pointer-types]
   91 |     {CONTROL_PIPE_REQ_LAC_STATUS, &control_handle_lac_status},
      |                                   ^
xl2tpd.c:91:35: note: (near initialization for 'control_handlers[10].handler')
xl2tpd.c:77:12: note: 'control_handle_lac_status' declared here
   77 | static int control_handle_lac_status();
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~
```