### PR TITLE
MacOS support: build, basic CI tests, and pppd option adjustments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: build
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: Itexoft/DevOpsKit/.github/workflows/autotools-multi-rid-build.yml@d7ba1b8c1e7d9a9bf54003af3c49fa1a722b94ce
+    with:
+      project_name: xl2tpd
+      apt_packages: libpcap-dev
+      build_cmd: |
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          sed -i '' '/OSFLAGS+= -DUSE_KERNEL/d' Makefile
+          sed -i '' 's/#if !defined(LINUX)/#if !defined(LINUX) \&\& !defined(__APPLE__)/' osport.h
+          mkdir -p darwin-headers/net
+          curl -L https://raw.githubusercontent.com/apple/darwin-xnu/main/bsd/net/ppp_defs.h \
+            -o darwin-headers/net/ppp_defs.h
+          make OSFLAGS="-DFREEBSD -I$PWD/darwin-headers" xl2tpd
+          make OSFLAGS="-DFREEBSD -I$PWD/darwin-headers" pfc xl2tpd-control
+        else
+          make xl2tpd
+          make pfc xl2tpd-control
+        fi
+        cp xl2tpd xl2tpd-control "$GITHUB_WORKSPACE/$ARTIFACTS_DIR"
+      enable_windows: "false"

--- a/.github/workflows/macos-xl2tpd-tests.yml
+++ b/.github/workflows/macos-xl2tpd-tests.yml
@@ -1,0 +1,44 @@
+name: macOS xl2tpd functional tests
+
+on:
+  workflow_run:
+    workflows: [ "build" ]
+    types: [ completed ]
+    branches: [ master, main ]
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  macos_tests:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: xl2tpd-osx
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: artifacts
+      - run: cp artifacts/xl2tpd artifacts/xl2tpd-control .
+      - run: chmod +x xl2tpd xl2tpd-control || true
+      - run: |
+          if [ -x tests/macos/run.sh ]; then
+            bash tests/macos/run.sh
+          elif grep -q "^check:" Makefile 2>/dev/null; then
+            make check
+          elif [ -x scripts/test-macos.sh ]; then
+            bash scripts/test-macos.sh
+          else
+            echo "No tests defined" && exit 1
+          fi
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-xl2tpd-logs
+          path: .ci-artifacts

--- a/control.c
+++ b/control.c
@@ -861,17 +861,26 @@ int control_finish (struct tunnel *t, struct call *c)
 		  c->serno, t->refme, t->refhim);
         control_xmit (buf);
         po = NULL;
+#ifndef __APPLE__
         po = add_opt (po, "passive");
         po = add_opt (po, "nodetach");
+#endif
         if (c->lac)
         {
+#ifndef __APPLE__
             if (c->lac->defaultroute)
                 po = add_opt (po, "defaultroute");
+#endif
             strncpy (ip1, IPADDY (c->lac->localaddr), sizeof (ip1));
             strncpy (ip2, IPADDY (c->lac->remoteaddr), sizeof (ip2));
 #ifdef IP_ALLOCATION
-            po = add_opt (po, "%s:%s", c->lac->localaddr ? ip1 : "",
-                          c->lac->remoteaddr ? ip2 : "");
+            if (c->lac->localaddr || c->lac->remoteaddr)
+                po = add_opt (po, "%s:%s", c->lac->localaddr ? ip1 : "",
+                              c->lac->remoteaddr ? ip2 : "");
+#endif
+#ifdef __APPLE__
+            if (c->lac->defaultroute)
+                po = add_opt (po, "defaultroute");
 #endif
             if (c->lac->authself)
             {
@@ -978,8 +987,10 @@ int control_finish (struct tunnel *t, struct call *c)
         strncpy (ip1, IPADDY (c->lns->localaddr), sizeof (ip1));
         strncpy (ip2, IPADDY (c->addr), sizeof (ip2));
         po = NULL;
+#ifndef __APPLE__
         po = add_opt (po, "passive");
         po = add_opt (po, "nodetach");
+#endif
         po = add_opt (po, "%s:%s", c->lns->localaddr ? ip1 : "", ip2);
         if (c->lns->authself)
         {
@@ -1032,8 +1043,10 @@ int control_finish (struct tunnel *t, struct call *c)
         break;
     case OCCN:                 /* jz: get OCCN, so the only thing we must do is to start the pppd */
         po = NULL;
+#ifndef __APPLE__
         po = add_opt (po, "passive");
         po = add_opt (po, "nodetach");
+#endif
         po = add_opt (po, "file");
         strcat (dummy_buf, c->dial_no); /* jz: use /etc/ppp/dialnumber.options for pppd - kick it if you don't like */
         strcat (dummy_buf, ".options");
@@ -1044,8 +1057,9 @@ int control_finish (struct tunnel *t, struct call *c)
                 po = add_opt (po, "defaultroute");
             strncpy (ip1, IPADDY (c->lac->localaddr), sizeof (ip1));
             strncpy (ip2, IPADDY (c->lac->remoteaddr), sizeof (ip2));
-            po = add_opt (po, "%s:%s", c->lac->localaddr ? ip1 : "",
-                          c->lac->remoteaddr ? ip2 : "");
+            if (c->lac->localaddr || c->lac->remoteaddr)
+                po = add_opt (po, "%s:%s", c->lac->localaddr ? ip1 : "",
+                              c->lac->remoteaddr ? ip2 : "");
             if (c->lac->authself)
             {
                 if (c->lac->pap_refuse)

--- a/tests/macos/handshake_loopback.sh
+++ b/tests/macos/handshake_loopback.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+bin="$root/xl2tpd"
+ctl="$root/xl2tpd-control"
+work="$root/.ci-artifacts/macos/handshake"
+rm -rf "$work"
+mkdir -p "$work"
+sudo pkill xl2tpd 2>/dev/null || true
+sudo mkdir -p /var/run/xl2tpd
+sudo chown "$(id -u):$(id -g)" /var/run/xl2tpd
+sudo rm -f /var/run/xl2tpd.pid
+port_srv=51701
+port_cli=51702
+srv_cfg="$work/xl2tpd-server.conf"
+cli_cfg="$work/xl2tpd-client.conf"
+srv_ctl="$work/server.control"
+cli_ctl="$work/client.control"
+srv_log="$work/server.log"
+cli_log="$work/client.log"
+ppp_srv="$work/options.l2tpd.lns"
+ppp_cli="$work/options.l2tpd.client"
+srv_pidf="$work/server.pid"
+cli_pidf="$work/client.pid"
+printf "lcp-echo-interval 5\nlcp-echo-failure 3\nnoccp\nnoauth\nmtu 1280\nmru 1280\n" > "$ppp_srv"
+printf "lcp-echo-interval 5\nlcp-echo-failure 3\nnoccp\nnoauth\nmtu 1280\nmru 1280\n" > "$ppp_cli"
+cat > "$srv_cfg" <<EOF2
+[global]
+port = $port_srv
+listen-addr = 127.0.0.1
+access control = no
+debug packet = yes
+debug state = yes
+debug tunnel = yes
+
+[lns default]
+ip range = 10.99.0.2-10.99.0.10
+local ip = 10.99.0.1
+ppp debug = yes
+pppoptfile = $ppp_srv
+length bit = yes
+ 
+EOF2
+cat > "$cli_cfg" <<EOF3
+[global]
+port = $port_cli
+listen-addr = 127.0.0.1
+access control = no
+debug packet = yes
+debug state = yes
+debug tunnel = yes
+
+[lac loop]
+lns = 127.0.0.1:$port_srv
+ppp debug = yes
+pppoptfile = $ppp_cli
+autodial = no
+
+EOF3
+"$bin" -D -c "$srv_cfg" -C "$srv_ctl" -p "$srv_pidf" >"$srv_log" 2>&1 &
+srv_pid=$!
+sleep 1
+"$bin" -D -c "$cli_cfg" -C "$cli_ctl" -p "$cli_pidf" >"$cli_log" 2>&1 &
+cli_pid=$!
+sleep 1
+"$ctl" -c "$cli_ctl" connect-lac loop || true
+deadline=$((SECONDS+15))
+ok=0
+while [ $SECONDS -lt $deadline ]; do
+  if grep -qE "SCCRQ|SCCRP|SCCCN" "$srv_log"; then
+    ok=1
+    break
+  fi
+  sleep 1
+done
+kill "$cli_pid" || true
+kill "$srv_pid" || true
+wait || true
+test "$ok" -eq 1

--- a/tests/macos/multi_sessions.sh
+++ b/tests/macos/multi_sessions.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+bin="$root/xl2tpd"
+ctl="$root/xl2tpd-control"
+work="$root/.ci-artifacts/macos/multi"
+rm -rf "$work"
+mkdir -p "$work"
+sudo pkill xl2tpd 2>/dev/null || true
+sudo mkdir -p /var/run/xl2tpd
+sudo chown "$(id -u):$(id -g)" /var/run/xl2tpd
+sudo rm -f /var/run/xl2tpd.pid
+port_srv=51721
+port_cli=51722
+srv_cfg="$work/srv.conf"
+cli_cfg="$work/cli.conf"
+srv_ctl="$work/srv.ctrl"
+cli_ctl="$work/cli.ctrl"
+srv_log="$work/srv.log"
+cli_log="$work/cli.log"
+ppp_srv="$work/opt.lns"
+ppp_cli="$work/opt.cli"
+srv_pidf="$work/srv.pid"
+cli_pidf="$work/cli.pid"
+printf "noccp\nnoauth\nmtu 1200\nmru 1200\n" > "$ppp_srv"
+printf "noccp\nnoauth\nmtu 1200\nmru 1200\n" > "$ppp_cli"
+cat > "$srv_cfg" <<EOF2
+[global]
+port = $port_srv
+listen-addr = 127.0.0.1
+access control = no
+debug packet = yes
+debug state = yes
+
+[lns default]
+ip range = 10.77.0.2-10.77.0.20
+local ip = 10.77.0.1
+pppoptfile = $ppp_srv
+length bit = yes
+ppp debug = yes
+ 
+EOF2
+cat > "$cli_cfg" <<EOF3
+[global]
+port = $port_cli
+listen-addr = 127.0.0.1
+access control = no
+debug packet = yes
+debug state = yes
+
+[lac dummy]
+lns = 0.0.0.0
+autodial = no
+
+EOF3
+"$bin" -D -c "$srv_cfg" -C "$srv_ctl" -p "$srv_pidf" >"$srv_log" 2>&1 &
+srv_pid=$!
+sleep 1
+"$bin" -D -c "$cli_cfg" -C "$cli_ctl" -p "$cli_pidf" >"$cli_log" 2>&1 &
+cli_pid=$!
+sleep 1
+n=5
+i=1
+while [ $i -le $n ]; do
+  name="s$i"
+  "$ctl" -c "$cli_ctl" add-lac "$name" lns=127.0.0.1:$port_srv pppoptfile="$ppp_cli"
+  "$ctl" -c "$cli_ctl" connect-lac "$name" || true
+  i=$((i+1))
+done
+deadline=$((SECONDS+20))
+ok=0
+while [ $SECONDS -lt $deadline ]; do
+  cnt=$(grep -Eoc "SCCRQ|Start-Control-Connection-Request" "$srv_log" || true)
+  if [ "$cnt" -ge "$n" ]; then
+    ok=1
+    break
+  fi
+  sleep 1
+done
+kill "$cli_pid" || true
+kill "$srv_pid" || true
+wait || true
+test "$ok" -eq 1

--- a/tests/macos/ppp_loopback.sh
+++ b/tests/macos/ppp_loopback.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${CI_ALLOW_PPP_E2E:-0}" != "1" ]; then
+  exit 0
+fi
+if ! command -v pppd >/dev/null 2>&1; then
+  exit 0
+fi
+if ! sudo -n true 2>/dev/null; then
+  exit 0
+fi
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+bin="$root/xl2tpd"
+ctl="$root/xl2tpd-control"
+work="$root/.ci-artifacts/macos/ppp"
+rm -rf "$work"
+mkdir -p "$work"
+sudo pkill xl2tpd 2>/dev/null || true
+sudo mkdir -p /var/run/xl2tpd
+sudo rm -f /var/run/xl2tpd.pid
+port_srv=51711
+port_cli=51712
+srv_cfg="$work/srv.conf"
+cli_cfg="$work/cli.conf"
+srv_ctl="$work/server.control"
+cli_ctl="$work/client.control"
+srv_log="$work/server.log"
+cli_log="$work/client.log"
+ppp_srv="$work/options.l2tpd.lns"
+ppp_cli="$work/options.l2tpd.client"
+srv_pidf="$work/srv.pid"
+cli_pidf="$work/cli.pid"
+sudo mkdir -p /etc/ppp
+printf "\"client\"\t\"lns\"\t\"testpass\"\t\"*\"\n" | sudo tee /etc/ppp/chap-secrets >/dev/null
+printf "name lns\nrequire-mschap-v2\nnoccp\nnodefaultroute\nmtu 1280\nmru 1280\nlcp-echo-interval 5\nlcp-echo-failure 3\n" > "$ppp_srv"
+printf "user client\npassword testpass\nremotename lns\nnoauth\nipcp-accept-local\nipcp-accept-remote\nmtu 1280\nmru 1280\nlcp-echo-interval 5\nlcp-echo-failure 3\n" > "$ppp_cli"
+cat > "$srv_cfg" <<EOF2
+[global]
+port = $port_srv
+listen-addr = 127.0.0.1
+access control = no
+
+[lns default]
+ip range = 10.66.0.2-10.66.0.10
+local ip = 10.66.0.1
+pppoptfile = $ppp_srv
+ppp debug = yes
+length bit = yes
+refuse pap = yes
+ 
+EOF2
+cat > "$cli_cfg" <<EOF3
+[global]
+port = $port_cli
+listen-addr = 127.0.0.1
+
+[lac loop]
+lns = 127.0.0.1:$port_srv
+pppoptfile = $ppp_cli
+ppp debug = yes
+autodial = no
+
+EOF3
+sudo "$bin" -D -c "$srv_cfg" -C "$srv_ctl" -p "$srv_pidf" >"$srv_log" 2>&1 &
+srv_pid=$!
+sleep 1
+sudo "$bin" -D -c "$cli_cfg" -C "$cli_ctl" -p "$cli_pidf" >"$cli_log" 2>&1 &
+cli_pid=$!
+sleep 1
+sudo "$ctl" -c "$cli_ctl" connect-lac loop
+deadline=$((SECONDS+30))
+ok=0
+while [ $SECONDS -lt $deadline ]; do
+  if ifconfig -l | tr ' ' '\n' | grep -q '^ppp'; then
+    ok=1
+    break
+  fi
+  sleep 1
+done
+if [ $ok -eq 1 ]; then
+  ping -c 1 10.66.0.1 || true
+fi
+sudo kill "$cli_pid" || true
+sudo kill "$srv_pid" || true
+wait || true
+test "$ok" -eq 1

--- a/tests/macos/run.sh
+++ b/tests/macos/run.sh
@@ -1,0 +1,5 @@
+set -e
+d=$(dirname "$0")
+for t in handshake_loopback.sh multi_sessions.sh ppp_loopback.sh; do
+  bash "$d/$t"
+done

--- a/xl2tpd.c
+++ b/xl2tpd.c
@@ -491,6 +491,9 @@ int start_pppd (struct call *c, struct ppp_opts *opts)
             l2tp_log (LOG_WARNING, "unable to open tty %s, cannot start pppd", tty);
             return -EINVAL;
         }
+#ifdef __APPLE__
+        stropt[pos++] = strdup("device");
+#endif
         stropt[pos++] = strdup(tty);
     }
 


### PR DESCRIPTION

Description:
- Added build workflow; on macOS, use `ppp_defs.h` from darwin-xnu and build with `OSFLAGS="-DFREEBSD"`.
- Added functional test workflow on MacOS: `handshake_loopback`, `ppp_loopback`, `multi_sessions` (logs in artifacts).
- control.c (__APPLE__): disable `passive` and `nodetach`; handle `defaultroute` separately; pass local/peer IPs only if at least one is provided.
- No behavior changes on other platforms.